### PR TITLE
fix: correct docstring to show actual [v, r, s] order

### DIFF
--- a/pytempo/models.py
+++ b/pytempo/models.py
@@ -478,7 +478,7 @@ class TempoTransaction:
             return sig.to_bytes()
 
         def fee_payer_sig_to_rlp(sig: Optional[Signature | bytes]) -> list | bytes:
-            """Encode fee_payer_signature as RLP list [r, s, v] or empty bytes."""
+            """Encode fee_payer_signature as RLP list [v, r, s] or empty bytes."""
             if sig is None:
                 return b""
             if isinstance(sig, bytes):


### PR DESCRIPTION
Addresses review comment from PR #7: https://github.com/tempoxyz/pytempo/pull/7#discussion_r2741970264

The docstring incorrectly said `[r, s, v]` but the actual encoding order is `[v, r, s]` (matching Tempo's `write_rlp_vrs()`).

Slack thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1769698125313369