### PR TITLE
fix(tests): use HIGH_GAS_LIMIT for first tx in test_set_user_fee_token

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -635,10 +635,11 @@ class TestSetUserFeeToken:
             "setUserToken(address)", Web3.to_checksum_address(BETA_USD)
         )
 
+        # Use HIGH_GAS_LIMIT for first tx (nonce=0) due to TIP-1000's 250k new account cost
         tx1 = TempoTransaction.create(
             chain_id=chain_id,
             nonce=nonce,
-            gas_limit=BASE_GAS_LIMIT,
+            gas_limit=HIGH_GAS_LIMIT,
             max_fee_per_gas=max_fee,
             max_priority_fee_per_gas=priority_fee,
             calls=(Call.create(to=FEE_CONTROLLER, data=set_calldata),),


### PR DESCRIPTION
## Summary
Fixes flaky `test_set_user_fee_token` test on devnet.

## Root Cause
TIP-1000 charges **250,000 gas for first transactions** from new accounts (nonce == 0) as anti-spam protection.

With `BASE_GAS_LIMIT` of 300k:
- 250,000 new account cost
- 21,000 base stipend
- ~1,000 calldata
= Only ~28,000 gas remaining for actual execution

The `setUserToken` precompile needs more than 28k gas to:
1. Cold-load betaUSD account to verify it's a valid TIP20
2. Read token currency
3. Write user preference to storage

## Fix
Use `HIGH_GAS_LIMIT` (500k) for the first transaction to ensure sufficient gas.

## Thread context
https://tempoxyz.slack.com/archives/C0A87C21805/p1769810166245569

cc @oliver-tempo