### PR TITLE
chore: rename package to tempopy and add changeset workflows

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,0 +1,24 @@
+# Changelogs
+
+This folder contains changelog files that describe changes to be released.
+
+## Adding a changelog
+
+Run `changelogs add` to create a new changelog file.
+
+## File format
+
+Changelog files are markdown with YAML frontmatter:
+
+```markdown
+---
+package-name: minor
+other-package: patch
+---
+
+Description of the changes made.
+```
+
+## Releasing
+
+Run `changelogs version` to apply version bumps and generate changelogs.

--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,8 @@
+ecosystem = "python"
+
+dependent_bump = "patch"
+
+[changelog]
+format = "root"
+
+ignore = []

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,41 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+      - name: Install changelogs
+        run: curl -sSL https://changelogs.sh | sh
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Generate changelog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md)' || true)
+          if [ -z "$CODE_CHANGES" ]; then
+            echo "No code changes requiring changelog, skipping"
+            exit 0
+          fi
+          ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref origin/${{ github.base_ref }}
+      - name: Commit changelog
+        run: |
+          if [ -n "$(git status --porcelain .changelog/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .changelog/
+            git commit -m "chore: add changelog"
+            git push
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Version
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: wevm/changelogs@master
+        with:
+          ecosystem: python
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          conventional-commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ Documentation = "https://github.com/tempoxyz/pytempo#readme"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# TODO: Remove once package is renamed back to "pytempo" on PyPI
 [tool.hatch.build.targets.wheel]
 packages = ["pytempo"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
-name = "pytempo"
+# TODO: Migrate package name back to "pytempo" once the name is reclaimed on PyPI
+name = "tempopy"
 version = "0.1.1"
 description = "Web3.py extension for Tempo blockchain - adds support for AA transactions and Tempo-specific features"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ Documentation = "https://github.com/tempoxyz/pytempo#readme"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["pytempo"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py39"


### PR DESCRIPTION
- Rename PyPI package from `pytempo` to `tempopy` (until we reclaim the `pytempo` name)
- Add changeset infrastructure (matching pympay):
  - `.changelog/` config
  - `changelog.yml` workflow (auto-generates changelog entries on PR open)
  - `publish.yml` workflow (versions and publishes to PyPI on merge to main)
  - `CHANGELOG.md`