### PR TITLE
chore: initial release

### DIFF
--- a/.changelog/initial-release.md
+++ b/.changelog/initial-release.md
@@ -1,0 +1,5 @@
+---
+tempopy: minor
+---
+
+Initial release of tempopy - Web3.py extension for Tempo blockchain with support for AA transactions and Tempo-specific features.


### PR DESCRIPTION
Adds a changeset to trigger the first publish of `tempopy` to PyPI.