### PR TITLE
chore: rename package from tempopy back to pytempo

### DIFF
--- a/.changelog/unique-bears-whisper.md
+++ b/.changelog/unique-bears-whisper.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Renamed package from tempopy back to pytempo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## `tempopy@0.2.0`
+## `pytempo@0.2.0`
 
 ### Minor Changes
 
-- Initial release of tempopy - Web3.py extension for Tempo blockchain with support for AA transactions and Tempo-specific features. (by @BrendanRyan, [#14](https://github.com/tempoxyz/pytempo/pull/14))
+- Initial release of pytempo - Web3.py extension for Tempo blockchain with support for AA transactions and Tempo-specific features. (by @BrendanRyan, [#14](https://github.com/tempoxyz/pytempo/pull/14))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## `pytempo@0.2.0`
+## `pytempo@0.2.1`
 
 ### Minor Changes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ tx_hash = w3.eth.send_raw_transaction(tx.encode())
 receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 ```
 
-## Typed API (v0.3.0+)
+## Typed API (v0.2.1+)
 
 The typed API provides immutable dataclasses with validation:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytempo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Web3.py extension for Tempo blockchain - adds support for AA transactions and Tempo-specific features"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
-# TODO: Migrate package name back to "pytempo" once the name is reclaimed on PyPI
-name = "tempopy"
+name = "pytempo"
 version = "0.2.0"
 description = "Web3.py extension for Tempo blockchain - adds support for AA transactions and Tempo-specific features"
 readme = "README.md"
@@ -28,10 +27,6 @@ Documentation = "https://github.com/tempoxyz/pytempo#readme"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# TODO: Remove once package is renamed back to "pytempo" on PyPI
-[tool.hatch.build.targets.wheel]
-packages = ["pytempo"]
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "pytempo"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/uv.lock
+++ b/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "pytempo"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
The `pytempo` name is now available on PyPI. This removes the `tempopy` workaround and the hatch wheel package override.

### Changes
- `pyproject.toml`: renamed package from `tempopy` to `pytempo`, removed hatch wheel override
- `CHANGELOG.md`: updated release name
- `uv.lock`: regenerated