### PR TITLE
docs: fix contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ See the `examples/` directory:
 
 ## Contributing
 
-Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/tempo?tab=contributing-ov-file).
+Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/pytempo?tab=contributing-ov-file).
 
 ## Security
 


### PR DESCRIPTION
The current Contributing link the README links to the main Tempo repo.

This PR changes it to link to the Contributing tab displayed on the pytempo repo.