### PR TITLE
fix: use V2 keychain signatures (0x04)

### DIFF
--- a/.changelog/cool-cows-clean.md
+++ b/.changelog/cool-cows-clean.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Fixed Keychain signature type identifier from `0x03` to `0x04` (V2 format) and updated the signing scheme to use `keccak256(0x04 || sig_hash || user_address)` instead of the raw sig_hash, providing domain separation to prevent cross-scheme signature confusion.

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -3,15 +3,19 @@
 The AccountKeychain precompile manages access key authorizations and spending limits.
 Access keys allow a separate key to sign transactions on behalf of a wallet.
 
-Per Tempo spec, Keychain signatures have format::
+Per Tempo spec, Keychain V2 signatures have format::
 
-    0x03 || user_address (20 bytes) || inner_signature (65 bytes)
+    0x04 || user_address (20 bytes) || inner_signature (65 bytes)
 
 Where:
 
-- 0x03 is the Keychain signature type identifier
+- 0x04 is the Keychain V2 signature type identifier
 - user_address is the root account (the account the access key signs on behalf of)
 - inner_signature is the secp256k1 signature from the access key (r || s || v)
+
+The access key signs ``keccak256(0x04 || sig_hash || user_address)`` rather than
+the raw sig_hash. The ``0x04`` domain separator prevents cross-scheme signature
+confusion.
 
 Total signature length: 86 bytes.
 
@@ -41,7 +45,7 @@ GET_REMAINING_LIMIT_SELECTOR = (
 )
 
 # Keychain signature constants
-KEYCHAIN_SIGNATURE_TYPE = 0x03
+KEYCHAIN_SIGNATURE_TYPE = 0x04
 INNER_SIGNATURE_LENGTH = 65  # r (32) + s (32) + v (1)
 KEYCHAIN_SIGNATURE_LENGTH = 86  # type (1) + address (20) + inner (65)
 
@@ -367,19 +371,29 @@ def build_keychain_signature(
     access_key_private_key: str,
     root_account: str,
 ) -> bytes:
-    """Build a Keychain signature for a message hash.
+    """Build a Keychain V2 signature for a message hash.
+
+    The access key signs ``keccak256(0x04 || sig_hash || user_address)``
+    instead of the raw sig_hash, providing domain separation.
 
     Args:
-        msg_hash: 32-byte hash to sign
+        msg_hash: 32-byte transaction signature hash
         access_key_private_key: Private key of the access key (hex string with 0x prefix)
         root_account: Address of the root account (hex string with 0x prefix)
 
     Returns:
-        86-byte Keychain signature: 0x03 || root_account (20 bytes) || inner_sig (65 bytes)
+        86-byte Keychain signature: 0x04 || root_account (20 bytes) || inner_sig (65 bytes)
     """
+    root_account_bytes = to_bytes(hexstr=root_account)
+
+    # Compute V2 signing hash: keccak256(0x04 || sig_hash || user_address)
+    signing_hash = keccak(
+        bytes([KEYCHAIN_SIGNATURE_TYPE]) + msg_hash + root_account_bytes
+    )
+
     # Sign with the access key
     account = Account.from_key(access_key_private_key)
-    signed_msg = account.unsafe_sign_hash(msg_hash)
+    signed_msg = account.unsafe_sign_hash(signing_hash)
 
     # Build the inner secp256k1 signature (65 bytes): r || s || v
     inner_sig = (
@@ -388,8 +402,7 @@ def build_keychain_signature(
         + bytes([signed_msg.v])
     )
 
-    # Build Keychain signature: 0x03 || root_account (20 bytes) || inner_sig (65 bytes)
-    root_account_bytes = to_bytes(hexstr=root_account)
+    # Build Keychain signature: 0x04 || root_account (20 bytes) || inner_sig (65 bytes)
     keychain_sig = bytes([KEYCHAIN_SIGNATURE_TYPE]) + root_account_bytes + inner_sig
 
     assert len(keychain_sig) == KEYCHAIN_SIGNATURE_LENGTH, (

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -188,8 +188,8 @@ class TestKeychainSignatureFormat:
         assert len(signed.sender_signature) == KEYCHAIN_SIGNATURE_LENGTH
         assert len(signed.sender_signature) == 86
 
-    def test_signature_starts_with_0x03(self):
-        """First byte must be 0x03 (Keychain type identifier)."""
+    def test_signature_starts_with_0x04(self):
+        """First byte must be 0x04 (Keychain V2 type identifier)."""
         access_key_private = "0x" + "a" * 64
         root_account = "0x" + "b" * 40
 
@@ -203,7 +203,7 @@ class TestKeychainSignatureFormat:
         signed = sign_tx_access_key(tx, access_key_private, root_account)
 
         assert signed.sender_signature[0] == KEYCHAIN_SIGNATURE_TYPE
-        assert signed.sender_signature[0] == 0x03
+        assert signed.sender_signature[0] == 0x04
 
     def test_root_account_embedded_in_signature(self):
         """Bytes 1-21 must contain the root account address."""
@@ -281,7 +281,7 @@ class TestKeychainVsNormalSigning:
         assert len(normal_signed.sender_signature.to_bytes()) == 65  # Normal secp256k1
 
     def test_different_type_prefix(self):
-        """Keychain starts with 0x03, normal doesn't."""
+        """Keychain starts with 0x04, normal doesn't."""
         access_key_private = "0x" + "a" * 64
         root_account = "0x" + "b" * 40
 
@@ -295,8 +295,8 @@ class TestKeychainVsNormalSigning:
         keychain_signed = sign_tx_access_key(tx, access_key_private, root_account)
         normal_signed = tx.sign(access_key_private)
 
-        assert keychain_signed.sender_signature[0] == 0x03
-        assert normal_signed.sender_signature.to_bytes()[0] != 0x03
+        assert keychain_signed.sender_signature[0] == 0x04
+        assert normal_signed.sender_signature.to_bytes()[0] != 0x04
 
     def test_encoded_transactions_different(self):
         """Encoded transactions should be different."""


### PR DESCRIPTION
Devnet activated T1C which rejects legacy V1 keychain signatures (type 0x03). Update to V2:

- Sign `keccak256(0x04 || sig_hash || user_address) instead of raw sig_hash` (domain separation)
- Wire type `0x03` -> `0x04`