### PR TITLE
ci: rename RPC URL secrets to TEMPO_ prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Run integration tests against devnet
         run: uv run pytest -v -s tests/test_integration.py
         env:
-          TEMPO_RPC_URL: ${{ secrets.DEVNET_RPC_URL }}
+          TEMPO_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
 
   integration-testnet:
     name: Integration Tests (Testnet)
@@ -177,4 +177,4 @@ jobs:
       - name: Run integration tests against testnet
         run: uv run pytest -v -s tests/test_integration.py
         env:
-          TEMPO_RPC_URL: ${{ secrets.TESTNET_RPC_URL }}
+          TEMPO_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}


### PR DESCRIPTION
## Summary
Renames `DEVNET_RPC_URL` and `TESTNET_RPC_URL` secret references to `TEMPO_DEVNET_RPC_URL` and `TEMPO_TESTNET_RPC_URL`.

## Changes
- `.github/workflows/ci.yml`: updated devnet and testnet integration test secret references

Co-Authored-By: onbjerg <8862627+onbjerg@users.noreply.github.com>

Prompted by: onberg