### PR TITLE
chore: force v0.3.0 instead of v1

### DIFF
--- a/.changelog/warm-sheep-wave.md
+++ b/.changelog/warm-sheep-wave.md
@@ -1,5 +1,7 @@
 ---
-pytempo: major
+pytempo: minor
 ---
+
+<!-- note: this is marked as a minor to bump to v0.x.x until we have a stable release !-->
 
 Removed the legacy transaction API (`LegacyTempoTransaction`, `TempoAATransaction`, `create_tempo_transaction`, `patch_web3_for_tempo`) and the `pytempo/transaction.py` module. Updated all examples, tests, and documentation to use only the typed `TempoTransaction` and `Call` API.


### PR DESCRIPTION
Currently the breaking change is marked as major which makes sense in the future, but seeing as we're still settling things I think we should stick to v0.x.y. This changes a changelog entry from major to minor, as v0.x.y in semver contains breaking changes between minor bumps.