### PR TITLE
fix: sync version metadata and remove stale legacy README API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,37 +59,8 @@ signed_tx = tx.sign("0xYourPrivateKey...")
 tx_hash = w3.eth.send_raw_transaction(signed_tx.encode())
 ```
 
-### Legacy API (Backwards Compatible)
-
-```python
-from pytempo import patch_web3_for_tempo, create_tempo_transaction
-from web3 import Web3
-
-# Step 1: Patch web3.py to add Tempo support
-# (Only needed if using web3's internal transaction parsing)
-patch_web3_for_tempo()
-
-# Step 2: Use web3.py normally with Tempo features
-w3 = Web3(Web3.HTTPProvider("https://rpc.testnet.tempo.xyz"))
-account = w3.eth.account.from_key("0x...")
-
-# Step 3: Create Tempo AA transaction (Type 0x76)
-tx = create_tempo_transaction(
-    to="0xRecipient...",
-    value=0,
-    gas=100000,
-    max_fee_per_gas=w3.eth.gas_price * 2,
-    max_priority_fee_per_gas=w3.eth.gas_price,
-    nonce=w3.eth.get_transaction_count(account.address),
-    chain_id=w3.eth.chain_id,
-    fee_token="0x20c0000000000000000000000000000000000001", # AlphaUSD
-)
-
-# Step 4: Sign and send using standard web3.py
-tx.sign(account.key.hex())
-tx_hash = w3.eth.send_raw_transaction(tx.encode())
-receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-```
+The legacy API (`create_tempo_transaction`, `patch_web3_for_tempo`) was removed in
+`v0.3.0`. Use the typed API shown above.
 
 ## Typed API (v0.2.1+)
 
@@ -150,42 +121,6 @@ h = as_hash32("0x" + "ab" * 32)  # -> bytes (32)
 
 # Convert hex strings to bytes
 data = as_bytes("0xabcdef")  # -> b'\xab\xcd\xef'
-```
-
-## Legacy Usage
-
-### Basic Transaction
-
-```python
-from pytempo import create_tempo_transaction
-
-tx = create_tempo_transaction(
-    to="0xRecipient...",
-    value=1000000000000000,
-    gas=100000,
-    max_fee_per_gas=2000000000,
-    max_priority_fee_per_gas=2000000000,
-    nonce=0,
-    chain_id=42429,
-)
-
-tx.sign("0xYourPrivateKey...")
-encoded = tx.encode()
-```
-
-### With Custom Fee Token
-
-```python
-tx = create_tempo_transaction(
-    to="0xRecipient...",
-    value=0,
-    fee_token="0xTokenAddress...",  # Pay gas in this ERC-20 token
-    gas=100000,
-    max_fee_per_gas=2000000000,
-    max_priority_fee_per_gas=2000000000,
-    nonce=0,
-    chain_id=42429,
-)
 ```
 
 ### Gas Sponsorship
@@ -313,32 +248,6 @@ EIP-2930 access list entry.
 
 - `AccessListItem.create(address, storage_keys=())` - Create with type coercion
 
-### `patch_web3_for_tempo()`
-
-Monkey patches web3.py to recognize Tempo AA transactions. **Must be called before using web3**.
-
-### `create_tempo_transaction(...)` (Legacy)
-
-Creates a mutable Tempo AA transaction.
-
-**Parameters:**
-
-- `to` (str): Destination address
-- `value` (int): Value in wei (default: 0)
-- `gas` (int): Gas limit
-- `max_fee_per_gas` (int): Maximum fee per gas
-- `max_priority_fee_per_gas` (int): Maximum priority fee per gas
-- `nonce` (int): Transaction nonce
-- `chain_id` (int): Chain ID
-- `nonce_key` (int): Nonce key for parallel execution (default: 0)
-- `fee_token` (str, optional): ERC-20 token address for gas payment
-- `calls` (list, optional): List of calls for batching
-- `data` (str, optional): Transaction data
-- `valid_before` (int, optional): Timestamp before which tx is valid
-- `valid_after` (int, optional): Timestamp after which tx becomes valid
-
-**Returns:** `LegacyTempoTransaction`
-
 ## Development
 
 ```bash
@@ -354,8 +263,7 @@ make check    # Run all checks (lint + format-check + test)
 See the `examples/` directory:
 
 - `simple_send.py` - Simple value transfer
-- `basic_transaction.py` - Transaction with fee token
-- `fee_payer_sponsored.py` - Gas sponsorship and call batching
+- `batch_calls.py` - Batch multiple calls
 
 ## Contributing
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,11 @@
 """Sphinx configuration for pytempo."""
 
+from pytempo import __version__
+
 project = "pytempo"
 copyright = "2025, Tempo"
 author = "Tempo"
-release = "0.3.0"
+release = __version__
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/pytempo/__init__.py
+++ b/pytempo/__init__.py
@@ -50,7 +50,7 @@ from .types import (
     as_optional_address,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     # Types

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,40 @@
+"""Version consistency tests."""
+
+import re
+import runpy
+from pathlib import Path
+
+from pytempo import __version__
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _project_version() -> str:
+    pyproject = ROOT / "pyproject.toml"
+    in_project_section = False
+    version_re = re.compile(r'^version\s*=\s*"([^"]+)"\s*$')
+
+    for raw_line in pyproject.read_text().splitlines():
+        line = raw_line.strip()
+
+        if line.startswith("[") and line.endswith("]"):
+            in_project_section = line == "[project]"
+            continue
+
+        if not in_project_section:
+            continue
+
+        match = version_re.match(line)
+        if match:
+            return match.group(1)
+
+    raise AssertionError("Unable to find [project].version in pyproject.toml")
+
+
+def test_package_version_matches_pyproject() -> None:
+    assert __version__ == _project_version()
+
+
+def test_docs_release_matches_package_version() -> None:
+    conf_vars = runpy.run_path(str(ROOT / "docs" / "conf.py"))
+    assert conf_vars["release"] == __version__

--- a/uv.lock
+++ b/uv.lock
@@ -913,7 +913,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1897,7 +1897,7 @@ wheels = [
 
 [[package]]
 name = "pytempo"
-version = "0.2.1"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
- sync `pytempo.__version__` with `pyproject.toml` (`0.3.1`)
- make Sphinx `release` derive from `pytempo.__version__` to avoid future drift
- remove stale README references to removed legacy APIs (`create_tempo_transaction`, `patch_web3_for_tempo`)
- update README examples list to match files that actually exist in `examples/`
- add `tests/test_version.py` regression tests for package/docs version consistency
- refresh `uv.lock` metadata so the editable `pytempo` package entry tracks `0.3.1`

## Problems Solved
- package runtime version was stale (`0.3.0`) while project metadata was `0.3.1`
- docs release string was hardcoded to the stale version
- README instructed users to import APIs that were removed in `v0.3.0`
- lock metadata still pointed at an older editable package version

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` (`84 passed`, `23 skipped`)

## Tradeoffs / Open Questions
- README now only documents the typed API and explicitly notes legacy API removal; no compatibility shim was reintroduced.
