### PR TITLE
docs: source Sphinx release from package version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,11 @@
 """Sphinx configuration for pytempo."""
 
+from pytempo import __version__
+
 project = "pytempo"
 copyright = "2025, Tempo"
 author = "Tempo"
-release = "0.3.0"
+release = __version__
 
 extensions = [
     "sphinx.ext.autodoc",


### PR DESCRIPTION
## Summary
- import __version__ from pytempo in docs/conf.py
- set Sphinx release to __version__ instead of a hardcoded literal

## Why
- keeps documentation version aligned with the package version automatically
- avoids future drift when versions are bumped

## Scope
- single-file change: docs/conf.py