### PR TITLE
fix(test): wait for block propagation before reusing access key

### DIFF
--- a/.changelog/old-bears-bow.md
+++ b/.changelog/old-bears-bow.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Fixed a test race condition in `TestAccessKeys` by waiting for block propagation before reusing an access key, ensuring load-balanced RPC nodes have imported the provisioning block.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -155,6 +155,22 @@ def send_tx(w3, tx: TempoTransaction, timeout: int = 60) -> dict:
     return receipt
 
 
+def wait_for_next_block(w3, timeout: int = 30) -> None:
+    """Wait until at least one new block is produced.
+
+    Useful when the RPC service is load-balanced across multiple nodes:
+    after a state-changing transaction is confirmed, a subsequent request may
+    hit a different backend whose ``latest()`` state hasn't caught up yet.
+    Waiting for a new block gives all nodes time to import the previous one.
+    """
+    start_block = w3.eth.block_number
+    deadline = time.time() + timeout
+    while w3.eth.block_number <= start_block:
+        if time.time() > deadline:
+            raise TimeoutError("Timed out waiting for next block")
+        time.sleep(0.25)
+
+
 def get_gas_params(w3) -> tuple[int, int]:
     """Get current gas parameters from the network."""
     gas_price = w3.eth.gas_price
@@ -500,6 +516,10 @@ class TestAccessKeys:
         )
         receipt1 = send_tx(w3, signed_tx1)
         assert receipt1["status"] == 1
+
+        # Wait for the next block so all nodes behind the load-balanced RPC
+        # service have imported the block that provisioned the access key.
+        wait_for_next_block(w3)
 
         # Build second tx and estimate gas (just keychain signature, no key_authorization)
         tx2 = TempoTransaction.create(


### PR DESCRIPTION
## Summary
Fix flaky `test_sign_tx_with_existing_access_key` test that fails intermittently with `access key does not exist` on load-balanced devnet RPCs.

## Motivation
The devnet RPC endpoint (`nodes-rpc-service`) load-balances across multiple nodes. When tx1 provisions an access key and tx2 immediately tries to reuse it via `send_raw_transaction`, tx2 may hit a different backend node whose `latest()` state hasn't imported the block containing tx1 yet. The pool validator then correctly rejects tx2 because the key doesn't exist in its state.

## Changes
- Added `wait_for_next_block()` helper that polls until at least one new block is produced
- Call it between tx1 confirmation and tx2 construction to give all nodes time to sync

## Testing
`ruff check` and `ruff format --check` pass. Full integration test requires a devnet — validated via CI workflow.

Co-Authored-By: onbjerg <8862627+onbjerg@users.noreply.github.com>

Prompted by: onbjerg