### PR TITLE
feat(keychain): add KeyRestrictions and integrate into authorize_key

### DIFF
--- a/.changelog/cute-rocks-fix.md
+++ b/.changelog/cute-rocks-fix.md
@@ -1,0 +1,5 @@
+---
+pytempo: minor
+---
+
+Added `KeyRestrictions` class with `is_unrestricted` and `is_call_allowed` introspection helpers, mirroring `tempo_alloy::KeyRestrictions`. Exported the new class from the top-level `pytempo` package and added comprehensive tests covering all resolution logic branches.

--- a/.changelog/cute-rocks-fix.md
+++ b/.changelog/cute-rocks-fix.md
@@ -2,4 +2,14 @@
 pytempo: minor
 ---
 
-Added `KeyRestrictions` class with `is_unrestricted` and `is_call_allowed` introspection helpers, mirroring `tempo_alloy::KeyRestrictions`. Exported the new class from the top-level `pytempo` package and added comprehensive tests covering all resolution logic branches.
+Added `KeyRestrictions` class for access-key restriction management and integrated it into `AccountKeychain.authorize_key()`.
+
+- `KeyRestrictions` with `expiry`, `limits`, `allowed_calls` fields
+- `is_unrestricted()` and `is_call_allowed(target, input_data)` introspection helpers
+- `to_abi_tuple()` for ABI encoding
+- `no_spending()` / `no_calls()` convenience constructors
+- `TokenLimit.period` field with uint64 validation
+- `AccountKeychain.authorize_key()` now takes `restrictions=KeyRestrictions(...)` (breaking)
+- `AccountKeychain.authorize_key_legacy()` convenience method
+- `KeyAuthorization` rejects periodic limits with a clear error
+- `CallScope.with_selector()` documented in access-keys guide

--- a/docs/guides/access-keys.md
+++ b/docs/guides/access-keys.md
@@ -82,17 +82,18 @@ print(f"Remaining: {remaining}")
 For on-chain key provisioning via the AccountKeychain precompile, you can restrict which contracts and functions the key is allowed to call:
 
 ```python
-from pytempo import CallScope, SignatureType
+from pytempo import CallScope, KeyRestrictions, SignatureType
 from pytempo.contracts import AccountKeychain, ALPHA_USD
 
 call = AccountKeychain.authorize_key(
     key_id="0xAccessKeyAddress...",
     signature_type=SignatureType.SECP256K1,
-    expiry=2**64 - 1,
-    allow_any_calls=False,
-    allowed_calls=(
-        CallScope.transfer(target=ALPHA_USD),
-        CallScope.approve(target=ALPHA_USD),
+    restrictions=KeyRestrictions(
+        expiry=2**64 - 1,
+        allowed_calls=[
+            CallScope.transfer(target=ALPHA_USD),
+            CallScope.approve(target=ALPHA_USD),
+        ],
     ),
 )
 ```
@@ -103,6 +104,7 @@ Available call scope constructors:
 - `CallScope.transfer(target=...)` — allow `transfer(address,uint256)` on a TIP20 token
 - `CallScope.approve(target=...)` — allow `approve(address,uint256)` on a TIP20 token
 - `CallScope.transfer_with_memo(target=...)` — allow `transferWithMemo(address,uint256,bytes32)` on a TIP20 token
+- `CallScope.with_selector(target=..., selector=...)` — allow an arbitrary 4-byte selector on any contract
 
 ```{note}
 Before T3 is activated, pass ``legacy=True`` to use the pre-T3 encoding::

--- a/pytempo/__init__.py
+++ b/pytempo/__init__.py
@@ -27,6 +27,7 @@ from .keychain import (
     CallScope,
     KeyAuthorization,
     KeychainSignature,
+    KeyRestrictions,
     SelectorRule,
     SignatureType,
     SignedKeyAuthorization,
@@ -78,6 +79,7 @@ __all__ = [
     "ACCOUNT_KEYCHAIN_ADDRESS",
     # Key authorization (inline access key provisioning)
     "KeyAuthorization",
+    "KeyRestrictions",
     "SignedKeyAuthorization",
     "SignatureType",
     "TokenLimit",

--- a/pytempo/contracts/account_keychain.py
+++ b/pytempo/contracts/account_keychain.py
@@ -53,7 +53,8 @@ class AccountKeychain:
             key_id: The access key address to authorize.
             signature_type: Type of key being authorized.
             restrictions: Key restrictions (expiry, limits, call scopes).
-            legacy: Use pre-T3 flat-parameter encoding.
+            legacy: Use pre-T3 flat-parameter encoding. Pass ``True``
+                until T3 is activated, then remove this argument.
         """
         if legacy:
             if restrictions.allowed_calls is not None:

--- a/pytempo/contracts/account_keychain.py
+++ b/pytempo/contracts/account_keychain.py
@@ -3,33 +3,26 @@
 Returns :class:`~pytempo.Call` objects ready to use in a
 :class:`~pytempo.TempoTransaction`::
 
-    from pytempo import SignatureType
+    from pytempo import KeyRestrictions, SignatureType
     from pytempo.contracts import AccountKeychain
 
-    # T3+ (default)
     call = AccountKeychain.authorize_key(
         key_id=access_key.address,
         signature_type=SignatureType.SECP256K1,
-        expiry=2**64 - 1,
-    )
-
-    # Pre-T3
-    call = AccountKeychain.authorize_key(
-        key_id=access_key.address,
-        signature_type=SignatureType.SECP256K1,
-        expiry=2**64 - 1,
-        legacy=True,
+        restrictions=KeyRestrictions(expiry=2**64 - 1),
     )
 
     tx = TempoTransaction.create(..., calls=(call,))
 """
 
+from __future__ import annotations
+
+import warnings
 from collections.abc import Sequence
-from typing import Optional
 
 from eth_utils import to_checksum_address
 
-from pytempo.keychain import CallScope, SignatureType
+from pytempo.keychain import CallScope, KeyRestrictions, SignatureType, TokenLimit
 from pytempo.models import Call
 
 from ._encode import encode_calldata
@@ -37,6 +30,68 @@ from .abis import ACCOUNT_KEYCHAIN_ABI
 from .addresses import ACCOUNT_KEYCHAIN_ADDRESS
 
 _ABI = ACCOUNT_KEYCHAIN_ABI
+
+
+def _resolve_restrictions(
+    *,
+    restrictions: KeyRestrictions | None,
+    expiry: int | None,
+    enforce_limits: bool,
+    limits: Sequence[tuple[str, int] | tuple[str, int, int]] | None,
+    allow_any_calls: bool,
+    allowed_calls: Sequence[CallScope] | None,
+) -> KeyRestrictions:
+    """Build a ``KeyRestrictions`` from either the new or deprecated params."""
+    _has_legacy = (
+        expiry is not None
+        or enforce_limits
+        or limits is not None
+        or not allow_any_calls
+        or allowed_calls is not None
+    )
+
+    if restrictions is not None:
+        if _has_legacy:
+            raise ValueError(
+                "cannot combine 'restrictions' with deprecated individual "
+                "params (expiry, limits, allowed_calls, …)"
+            )
+        return restrictions
+
+    if not _has_legacy:
+        return KeyRestrictions()
+
+    warnings.warn(
+        "Passing individual expiry/limits/allowed_calls params is deprecated. "
+        "Use restrictions=KeyRestrictions(...) instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+    if allowed_calls and allow_any_calls:
+        raise ValueError(
+            "allowed_calls was provided but allow_any_calls=True; "
+            "pass allow_any_calls=False to create a scoped key"
+        )
+
+    token_limits: list[TokenLimit] | None = None
+    if enforce_limits or limits is not None:
+        token_limits = []
+        if limits:
+            for lim in limits:
+                t, a = lim[0], lim[1]
+                p = lim[2] if len(lim) > 2 else 0  # type: ignore[arg-type]
+                token_limits.append(TokenLimit(token=t, limit=a, period=p))
+
+    resolved_calls: list[CallScope] | None = None
+    if not allow_any_calls:
+        resolved_calls = list(allowed_calls) if allowed_calls else []
+
+    return KeyRestrictions(
+        expiry=expiry,
+        limits=token_limits,
+        allowed_calls=resolved_calls,
+    )
 
 
 class AccountKeychain:
@@ -52,73 +107,70 @@ class AccountKeychain:
         *,
         key_id: str,
         signature_type: SignatureType,
-        expiry: int,
-        enforce_limits: bool = False,
-        limits: Optional[Sequence[tuple[str, int] | tuple[str, int, int]]] = None,
-        allow_any_calls: bool = True,
-        allowed_calls: Optional[Sequence[CallScope]] = None,
+        restrictions: KeyRestrictions | None = None,
         legacy: bool = False,
+        # Deprecated individual params — use ``restrictions`` instead.
+        expiry: int | None = None,
+        enforce_limits: bool = False,
+        limits: Sequence[tuple[str, int] | tuple[str, int, int]] | None = None,
+        allow_any_calls: bool = True,
+        allowed_calls: Sequence[CallScope] | None = None,
     ) -> Call:
         """Build an ``authorizeKey`` call.
 
-        Uses the TIP-1011 ``KeyRestrictions`` struct encoding by default (T3+).
-        Pass ``legacy=True`` for the pre-T3 flat-parameter encoding.
+        Pass a :class:`~pytempo.KeyRestrictions` for the recommended API::
+
+            AccountKeychain.authorize_key(
+                key_id=addr,
+                signature_type=SignatureType.SECP256K1,
+                restrictions=KeyRestrictions(expiry=2**64 - 1),
+            )
+
+        The individual ``expiry`` / ``limits`` / ``allowed_calls`` params are
+        deprecated but still supported for backward compatibility.
 
         Args:
             key_id: The access key address to authorize.
-            signature_type: Type of key being authorized (SignatureType.SECP256K1, P256, or WEBAUTHN)
-            expiry: Unix timestamp when key expires (use ``2**64 - 1`` for never).
-            enforce_limits: Whether to enforce spending limits.
-            limits: List of ``(token_address, amount)`` or ``(token_address, amount, period)`` tuples.
-                Period defaults to 0 (one-time limit) if omitted.
-            allow_any_calls: Whether the key can call any contract (default True).
-                Ignored when ``legacy=True``.
-            allowed_calls: List of :class:`~pytempo.CallScope` restricting
-                which contracts/functions the key can call.
-                Only used when ``allow_any_calls`` is False.
-                Ignored when ``legacy=True``.
-            legacy: Use pre-T3 flat-parameter encoding. Pass ``True`` until T3 is activated, then remove this argument.
+            signature_type: Type of key being authorized.
+            restrictions: Key restrictions (expiry, limits, call scopes).
+            legacy: Use pre-T3 flat-parameter encoding.
         """
-        if legacy and (allowed_calls or not allow_any_calls):
-            raise ValueError("legacy=True does not support call restrictions")
-
-        if allowed_calls and allow_any_calls:
-            raise ValueError(
-                "allowed_calls was provided but allow_any_calls=True; "
-                "pass allow_any_calls=False to create a scoped key"
-            )
+        r = _resolve_restrictions(
+            restrictions=restrictions,
+            expiry=expiry,
+            enforce_limits=enforce_limits,
+            limits=limits,
+            allow_any_calls=allow_any_calls,
+            allowed_calls=allowed_calls,
+        )
 
         if legacy:
+            if r.allowed_calls is not None:
+                raise ValueError("legacy=True does not support call restrictions")
+            if r.limits and any(lim.period != 0 for lim in r.limits):
+                raise ValueError("legacy=True does not support periodic limits")
+
             limit_tuples = (
-                [(t, a) for t, a, *_ in ((*lim, 0)[:3] for lim in limits)]
-                if limits
+                [(bytes(lim.token).hex(), lim.limit) for lim in r.limits]
+                if r.limits
                 else []
             )
             data = encode_calldata(
                 _ABI,
                 "authorizeKey",
-                [key_id, int(signature_type), expiry, enforce_limits, limit_tuples],
+                [
+                    key_id,
+                    int(signature_type),
+                    r.expiry if r.expiry is not None else 2**64 - 1,
+                    r.limits is not None,
+                    limit_tuples,
+                ],
             )
         else:
-            limit_tuples = (
-                [(t, a, p) for t, a, p in ((*lim, 0)[:3] for lim in limits)]
-                if limits
-                else []
-            )
-            call_tuples = (
-                [s.to_abi_tuple() for s in allowed_calls] if allowed_calls else []
-            )
-            config = (
-                expiry,
-                enforce_limits,
-                limit_tuples,
-                allow_any_calls,
-                call_tuples,
-            )
             data = encode_calldata(
                 _ABI,
                 "authorizeKey",
-                [key_id, int(signature_type), config],
+                [key_id, int(signature_type), r.to_abi_tuple()],
             )
 
         return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)

--- a/pytempo/contracts/account_keychain.py
+++ b/pytempo/contracts/account_keychain.py
@@ -17,12 +17,11 @@ Returns :class:`~pytempo.Call` objects ready to use in a
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 
 from eth_utils import to_checksum_address
 
-from pytempo.keychain import CallScope, KeyRestrictions, SignatureType, TokenLimit
+from pytempo.keychain import CallScope, KeyRestrictions, SignatureType
 from pytempo.models import Call
 
 from ._encode import encode_calldata
@@ -30,68 +29,6 @@ from .abis import ACCOUNT_KEYCHAIN_ABI
 from .addresses import ACCOUNT_KEYCHAIN_ADDRESS
 
 _ABI = ACCOUNT_KEYCHAIN_ABI
-
-
-def _resolve_restrictions(
-    *,
-    restrictions: KeyRestrictions | None,
-    expiry: int | None,
-    enforce_limits: bool,
-    limits: Sequence[tuple[str, int] | tuple[str, int, int]] | None,
-    allow_any_calls: bool,
-    allowed_calls: Sequence[CallScope] | None,
-) -> KeyRestrictions:
-    """Build a ``KeyRestrictions`` from either the new or deprecated params."""
-    _has_legacy = (
-        expiry is not None
-        or enforce_limits
-        or limits is not None
-        or not allow_any_calls
-        or allowed_calls is not None
-    )
-
-    if restrictions is not None:
-        if _has_legacy:
-            raise ValueError(
-                "cannot combine 'restrictions' with deprecated individual "
-                "params (expiry, limits, allowed_calls, …)"
-            )
-        return restrictions
-
-    if not _has_legacy:
-        return KeyRestrictions()
-
-    warnings.warn(
-        "Passing individual expiry/limits/allowed_calls params is deprecated. "
-        "Use restrictions=KeyRestrictions(...) instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-    if allowed_calls and allow_any_calls:
-        raise ValueError(
-            "allowed_calls was provided but allow_any_calls=True; "
-            "pass allow_any_calls=False to create a scoped key"
-        )
-
-    token_limits: list[TokenLimit] | None = None
-    if enforce_limits or limits is not None:
-        token_limits = []
-        if limits:
-            for lim in limits:
-                t, a = lim[0], lim[1]
-                p = lim[2] if len(lim) > 2 else 0  # type: ignore[arg-type]
-                token_limits.append(TokenLimit(token=t, limit=a, period=p))
-
-    resolved_calls: list[CallScope] | None = None
-    if not allow_any_calls:
-        resolved_calls = list(allowed_calls) if allowed_calls else []
-
-    return KeyRestrictions(
-        expiry=expiry,
-        limits=token_limits,
-        allowed_calls=resolved_calls,
-    )
 
 
 class AccountKeychain:
@@ -107,27 +44,10 @@ class AccountKeychain:
         *,
         key_id: str,
         signature_type: SignatureType,
-        restrictions: KeyRestrictions | None = None,
+        restrictions: KeyRestrictions,
         legacy: bool = False,
-        # Deprecated individual params — use ``restrictions`` instead.
-        expiry: int | None = None,
-        enforce_limits: bool = False,
-        limits: Sequence[tuple[str, int] | tuple[str, int, int]] | None = None,
-        allow_any_calls: bool = True,
-        allowed_calls: Sequence[CallScope] | None = None,
     ) -> Call:
         """Build an ``authorizeKey`` call.
-
-        Pass a :class:`~pytempo.KeyRestrictions` for the recommended API::
-
-            AccountKeychain.authorize_key(
-                key_id=addr,
-                signature_type=SignatureType.SECP256K1,
-                restrictions=KeyRestrictions(expiry=2**64 - 1),
-            )
-
-        The individual ``expiry`` / ``limits`` / ``allowed_calls`` params are
-        deprecated but still supported for backward compatibility.
 
         Args:
             key_id: The access key address to authorize.
@@ -135,24 +55,17 @@ class AccountKeychain:
             restrictions: Key restrictions (expiry, limits, call scopes).
             legacy: Use pre-T3 flat-parameter encoding.
         """
-        r = _resolve_restrictions(
-            restrictions=restrictions,
-            expiry=expiry,
-            enforce_limits=enforce_limits,
-            limits=limits,
-            allow_any_calls=allow_any_calls,
-            allowed_calls=allowed_calls,
-        )
-
         if legacy:
-            if r.allowed_calls is not None:
+            if restrictions.allowed_calls is not None:
                 raise ValueError("legacy=True does not support call restrictions")
-            if r.limits and any(lim.period != 0 for lim in r.limits):
+            if restrictions.limits and any(
+                lim.period != 0 for lim in restrictions.limits
+            ):
                 raise ValueError("legacy=True does not support periodic limits")
 
             limit_tuples = (
-                [(bytes(lim.token).hex(), lim.limit) for lim in r.limits]
-                if r.limits
+                [(bytes(lim.token).hex(), lim.limit) for lim in restrictions.limits]
+                if restrictions.limits
                 else []
             )
             data = encode_calldata(
@@ -161,8 +74,10 @@ class AccountKeychain:
                 [
                     key_id,
                     int(signature_type),
-                    r.expiry if r.expiry is not None else 2**64 - 1,
-                    r.limits is not None,
+                    restrictions.expiry
+                    if restrictions.expiry is not None
+                    else 2**64 - 1,
+                    restrictions.limits is not None,
                     limit_tuples,
                 ],
             )
@@ -170,10 +85,29 @@ class AccountKeychain:
             data = encode_calldata(
                 _ABI,
                 "authorizeKey",
-                [key_id, int(signature_type), r.to_abi_tuple()],
+                [key_id, int(signature_type), restrictions.to_abi_tuple()],
             )
 
         return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)
+
+    @staticmethod
+    def authorize_key_legacy(
+        *,
+        key_id: str,
+        signature_type: SignatureType,
+        restrictions: KeyRestrictions,
+    ) -> Call:
+        """Build a pre-T3 ``authorizeKey`` call.
+
+        Convenience wrapper equivalent to
+        ``authorize_key(..., legacy=True)``.
+        """
+        return AccountKeychain.authorize_key(
+            key_id=key_id,
+            signature_type=signature_type,
+            restrictions=restrictions,
+            legacy=True,
+        )
 
     @staticmethod
     def revoke_key(*, key_id: str) -> Call:

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -279,6 +279,100 @@ class CallScope:
 
 
 # ---------------------------------------------------------------------------
+# Key restrictions (introspection helpers)
+# ---------------------------------------------------------------------------
+
+
+def _convert_token_limits(
+    value: tuple[TokenLimit, ...] | list[TokenLimit] | None,
+) -> tuple[TokenLimit, ...] | None:
+    return None if value is None else tuple(value)
+
+
+def _convert_call_scopes(
+    value: tuple[CallScope, ...] | list[CallScope] | None,
+) -> tuple[CallScope, ...] | None:
+    return None if value is None else tuple(value)
+
+
+@attrs.define(frozen=True)
+class KeyRestrictions:
+    """Runtime introspection over a set of key restrictions.
+
+    Mirrors ``tempo_alloy::KeyRestrictions``.  Use this to check whether a
+    particular call would be permitted by a configured set of call scopes.
+
+    Args:
+        expiry: Unix timestamp when the key expires.  ``None`` means never.
+        limits: Optional token spending limits.
+        allowed_calls: Optional call scope allowlist.
+            ``None`` means unrestricted (any call allowed).
+    """
+
+    expiry: int | None = attrs.field(default=None)
+    limits: tuple[TokenLimit, ...] | None = attrs.field(
+        default=None, converter=_convert_token_limits
+    )
+    allowed_calls: tuple[CallScope, ...] | None = attrs.field(
+        default=None, converter=_convert_call_scopes
+    )
+
+    def is_unrestricted(self) -> bool:
+        """Return ``True`` if calls are unrestricted (no allowlist set)."""
+        return self.allowed_calls is None
+
+    def is_call_allowed(self, target: BytesLike, input_data: bytes = b"") -> bool:
+        """Check whether a call to *target* with *input_data* is permitted.
+
+        Resolution order (matches the Rust implementation):
+
+        1. No scopes configured → unrestricted, always allowed.
+        2. Target not in any scope → denied.
+        3. Scope has no selector rules → any call to that target is allowed.
+        4. Selector not in rules → denied.
+        5. Rule has no recipients → any recipient is allowed.
+        6. Otherwise the first ABI word after the selector must match an
+           allowed recipient.
+        """
+        if self.allowed_calls is None:
+            return True
+
+        addr = as_address(target)
+
+        scope = next(
+            (s for s in self.allowed_calls if s.target == addr),
+            None,
+        )
+        if scope is None:
+            return False
+
+        rules = scope.selector_rules
+        if not rules:
+            return True
+
+        if len(input_data) < 4:
+            return False
+
+        selector = Selector(input_data[:4])
+        rule = next(
+            (r for r in rules if r.selector == selector),
+            None,
+        )
+        if rule is None:
+            return False
+
+        if not rule.recipients:
+            return True
+
+        if len(input_data) < 36:
+            return False
+
+        word = input_data[4:36]
+        recipient = as_address(word[12:])
+        return recipient in rule.recipients
+
+
+# ---------------------------------------------------------------------------
 # Key authorization
 # ---------------------------------------------------------------------------
 

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -301,8 +301,7 @@ def _convert_call_scopes(
 class KeyRestrictions:
     """Access-key restrictions used for AccountKeychain call builders.
 
-    Mirrors ``tempo_alloy::KeyRestrictions``.  Pass to
-    :meth:`~pytempo.contracts.AccountKeychain.authorize_key` and use
+    Pass to :meth:`~pytempo.contracts.AccountKeychain.authorize_key` and use
     :meth:`is_call_allowed` for local permission checks.
 
     Args:

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -88,13 +88,15 @@ class TokenLimit:
 
     Args:
         token: TIP20 token address
-        limit: Maximum spending amount for this token (enforced over the key's lifetime)
+        limit: Maximum spending amount for this token
+        period: Limit period in seconds (0 = one-time / lifetime limit)
     """
 
     token: Address = attrs.field(
         converter=as_address, validator=validate_nonempty_address
     )
     limit: int = attrs.field(validator=_validate_u256)
+    period: int = attrs.field(default=0, validator=attrs.validators.ge(0))
 
     def to_rlp(self) -> list:
         return [bytes(self.token), self.limit]
@@ -279,7 +281,7 @@ class CallScope:
 
 
 # ---------------------------------------------------------------------------
-# Key restrictions (introspection helpers)
+# Key restrictions
 # ---------------------------------------------------------------------------
 
 
@@ -297,16 +299,33 @@ def _convert_call_scopes(
 
 @attrs.define(frozen=True)
 class KeyRestrictions:
-    """Runtime introspection over a set of key restrictions.
+    """Access-key restrictions used for AccountKeychain call builders.
 
-    Mirrors ``tempo_alloy::KeyRestrictions``.  Use this to check whether a
-    particular call would be permitted by a configured set of call scopes.
+    Mirrors ``tempo_alloy::KeyRestrictions``.  Pass to
+    :meth:`~pytempo.contracts.AccountKeychain.authorize_key` and use
+    :meth:`is_call_allowed` for local permission checks.
 
     Args:
         expiry: Unix timestamp when the key expires.  ``None`` means never.
         limits: Optional token spending limits.
+            ``None`` means unlimited, ``()`` means deny all spending.
         allowed_calls: Optional call scope allowlist.
-            ``None`` means unrestricted (any call allowed).
+            ``None`` means unrestricted (any call allowed), ``()`` means
+            deny all calls.
+
+    Examples::
+
+        from pytempo import KeyRestrictions, CallScope, TokenLimit
+
+        # Unrestricted key that expires
+        r = KeyRestrictions(expiry=1893456000)
+
+        # Scoped to TIP-20 transfers with a spending limit
+        r = KeyRestrictions(
+            expiry=1893456000,
+            limits=[TokenLimit(token=ALPHA_USD, limit=1000)],
+            allowed_calls=[CallScope.transfer(target=ALPHA_USD)],
+        )
     """
 
     expiry: int | None = attrs.field(default=None)
@@ -316,6 +335,20 @@ class KeyRestrictions:
     allowed_calls: tuple[CallScope, ...] | None = attrs.field(
         default=None, converter=_convert_call_scopes
     )
+
+    # -- Convenience constructors -------------------------------------------
+
+    @classmethod
+    def no_spending(cls) -> KeyRestrictions:
+        """Deny all spending (enforce limits with an empty allowlist)."""
+        return cls(limits=())
+
+    @classmethod
+    def no_calls(cls) -> KeyRestrictions:
+        """Deny all calls (scoped mode with an empty allowlist)."""
+        return cls(allowed_calls=())
+
+    # -- Introspection ------------------------------------------------------
 
     def is_unrestricted(self) -> bool:
         """Return ``True`` if calls are unrestricted (no allowlist set)."""
@@ -370,6 +403,32 @@ class KeyRestrictions:
         word = input_data[4:36]
         recipient = as_address(word[12:])
         return recipient in rule.recipients
+
+    # -- ABI encoding -------------------------------------------------------
+
+    def to_abi_tuple(self) -> tuple:
+        """Convert to ABI-encodable ``KeyRestrictions`` struct.
+
+        Returns the tuple ``(expiry, enforceLimits, limits, allowAnyCalls,
+        allowedCalls)`` expected by the ``authorizeKey`` precompile.
+        """
+        limit_tuples = (
+            [(bytes(lim.token), lim.limit, lim.period) for lim in self.limits]
+            if self.limits is not None
+            else []
+        )
+        call_tuples = (
+            [s.to_abi_tuple() for s in self.allowed_calls]
+            if self.allowed_calls is not None
+            else []
+        )
+        return (
+            self.expiry if self.expiry is not None else 2**64 - 1,
+            self.limits is not None,
+            limit_tuples,
+            self.allowed_calls is None,
+            call_tuples,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -79,6 +79,18 @@ def _validate_u256(instance: object, attribute: object, value: int) -> None:
         raise ValueError(f"limit must be in [0, 2**256 - 1], got {value}")
 
 
+def _validate_u64(instance: object, attribute: object, value: int) -> None:
+    if not (0 <= value <= 2**64 - 1):
+        raise ValueError(f"value must be in [0, 2**64 - 1], got {value}")
+
+
+def _validate_optional_u64(
+    instance: object, attribute: object, value: int | None
+) -> None:
+    if value is not None and not (0 <= value <= 2**64 - 1):
+        raise ValueError(f"value must be in [0, 2**64 - 1], got {value}")
+
+
 @attrs.define(frozen=True)
 class TokenLimit:
     """Token spending limit for access keys.
@@ -96,7 +108,7 @@ class TokenLimit:
         converter=as_address, validator=validate_nonempty_address
     )
     limit: int = attrs.field(validator=_validate_u256)
-    period: int = attrs.field(default=0, validator=attrs.validators.ge(0))
+    period: int = attrs.field(default=0, validator=_validate_u64)
 
     def to_rlp(self) -> list:
         return [bytes(self.token), self.limit]
@@ -327,7 +339,7 @@ class KeyRestrictions:
         )
     """
 
-    expiry: int | None = attrs.field(default=None)
+    expiry: int | None = attrs.field(default=None, validator=_validate_optional_u64)
     limits: tuple[TokenLimit, ...] | None = attrs.field(
         default=None, converter=_convert_token_limits
     )
@@ -474,6 +486,16 @@ class KeyAuthorization:
     limits: tuple[TokenLimit, ...] | None = attrs.field(
         default=None, converter=_convert_limits
     )
+
+    def __attrs_post_init__(self) -> None:
+        if self.limits:
+            for lim in self.limits:
+                if lim.period != 0:
+                    raise ValueError(
+                        "inline KeyAuthorization does not support periodic limits "
+                        f"(token={bytes(lim.token).hex()}, period={lim.period}); "
+                        "use AccountKeychain.authorize_key() with KeyRestrictions instead"
+                    )
 
     def as_rlp_payload(self) -> list:
         """Return the RLP-encodable list representation."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,6 +26,7 @@ from web3 import Web3
 from pytempo import (
     Call,
     KeyAuthorization,
+    KeyRestrictions,
     SignatureType,
     TempoTransaction,
     TokenLimit,
@@ -793,10 +794,8 @@ class TestKeychainSelectors:
         nonce = w3.eth.get_transaction_count(funded_account.address)
         auth_call = AccountKeychain.authorize_key(
             key_id=access_key.address,
-            signature_type=0,
-            expiry=expiry,
-            enforce_limits=False,
-            limits=[],
+            signature_type=SignatureType.SECP256K1,
+            restrictions=KeyRestrictions(expiry=expiry),
             legacy=is_t2,
         )
         tx = TempoTransaction.create(
@@ -870,10 +869,11 @@ class TestKeychainWithLimits:
         nonce = w3.eth.get_transaction_count(funded_account.address)
         auth_call = AccountKeychain.authorize_key(
             key_id=access_key.address,
-            signature_type=0,
-            expiry=expiry,
-            enforce_limits=True,
-            limits=[(PATH_USD, limit_amount)],
+            signature_type=SignatureType.SECP256K1,
+            restrictions=KeyRestrictions(
+                expiry=expiry,
+                limits=[TokenLimit(token=PATH_USD, limit=limit_amount)],
+            ),
         )
         tx = TempoTransaction.create(
             chain_id=chain_id,

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -897,17 +897,7 @@ class TestAuthorizeKeyWithRestrictions:
         )
         assert call.data is not None
 
-    def test_rejects_mixed_restrictions_and_legacy_params(self):
-        r = KeyRestrictions(expiry=2**64 - 1)
-        with pytest.raises(ValueError, match="cannot combine"):
-            AccountKeychain.authorize_key(
-                key_id="0x" + "11" * 20,
-                signature_type=SignatureType.SECP256K1,
-                restrictions=r,
-                expiry=999,
-            )
-
-    def test_legacy_with_restrictions_rejects_call_scopes(self):
+    def test_legacy_rejects_call_scopes(self):
         scope = CallScope.transfer(target=ALPHA_USD)
         r = KeyRestrictions(allowed_calls=[scope])
         with pytest.raises(ValueError, match="call restrictions"):
@@ -935,40 +925,21 @@ class TestAuthorizeKeyWithRestrictions:
         )
         assert call.data is not None
 
-
-class TestAuthorizeKeyGuards:
-    """Tests for authorize_key deprecated param validation."""
-
-    def test_rejects_allowed_calls_with_allow_any_calls_true(self):
-        scope = CallScope.transfer(target=ALPHA_USD)
-        with pytest.raises(ValueError, match="allow_any_calls"):
-            AccountKeychain.authorize_key(
-                key_id="0x" + "11" * 20,
-                signature_type=SignatureType.SECP256K1,
-                expiry=2**64 - 1,
-                allowed_calls=[scope],
-            )
-
-    def test_rejects_legacy_with_call_restrictions(self):
-        scope = CallScope.transfer(target=ALPHA_USD)
-        with pytest.raises(ValueError, match="legacy|call restrictions"):
-            AccountKeychain.authorize_key(
-                key_id="0x" + "11" * 20,
-                signature_type=SignatureType.SECP256K1,
-                expiry=2**64 - 1,
-                allowed_calls=[scope],
-                allow_any_calls=False,
-                legacy=True,
-            )
-
-    def test_accepts_allowed_calls_with_allow_any_calls_false(self):
-        scope = CallScope.transfer(target=ALPHA_USD)
+    def test_no_spending_restrictions(self):
+        r = KeyRestrictions.no_spending()
         call = AccountKeychain.authorize_key(
             key_id="0x" + "11" * 20,
             signature_type=SignatureType.SECP256K1,
-            expiry=2**64 - 1,
-            allowed_calls=[scope],
-            allow_any_calls=False,
+            restrictions=r,
+        )
+        assert call.data is not None
+
+    def test_authorize_key_legacy_convenience(self):
+        r = KeyRestrictions(expiry=999)
+        call = AccountKeychain.authorize_key_legacy(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=r,
         )
         assert call.data is not None
 

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -511,6 +511,22 @@ class TestTokenLimit:
         with pytest.raises(AttributeError):
             limit.limit = 2000  # type: ignore[misc]
 
+    def test_period_defaults_to_zero(self):
+        limit = TokenLimit(token="0x" + "a" * 40, limit=1000)
+        assert limit.period == 0
+
+    def test_accepts_valid_period(self):
+        limit = TokenLimit(token="0x" + "a" * 40, limit=1000, period=3600)
+        assert limit.period == 3600
+
+    def test_rejects_negative_period(self):
+        with pytest.raises(ValueError):
+            TokenLimit(token="0x" + "a" * 40, limit=1000, period=-1)
+
+    def test_rejects_period_exceeding_u64(self):
+        with pytest.raises(ValueError):
+            TokenLimit(token="0x" + "a" * 40, limit=1000, period=2**64)
+
 
 class TestKeyAuthorization:
     """Tests for KeyAuthorization attrs model."""
@@ -1106,3 +1122,35 @@ class TestKeyRestrictionsIsCallAllowed:
         r = KeyRestrictions()
         with pytest.raises(AttributeError):
             r.allowed_calls = []  # type: ignore[misc]
+
+    def test_rejects_negative_expiry(self):
+        with pytest.raises(ValueError):
+            KeyRestrictions(expiry=-1)
+
+    def test_rejects_expiry_exceeding_u64(self):
+        with pytest.raises(ValueError):
+            KeyRestrictions(expiry=2**64)
+
+    def test_accepts_max_u64_expiry(self):
+        r = KeyRestrictions(expiry=2**64 - 1)
+        assert r.expiry == 2**64 - 1
+
+
+class TestKeyAuthorizationPeriodicLimits:
+    """KeyAuthorization rejects periodic limits (inline auth doesn't support them)."""
+
+    def test_rejects_periodic_limit(self):
+        with pytest.raises(ValueError, match="periodic limits"):
+            KeyAuthorization(
+                key_id="0x" + "bb" * 20,
+                chain_id=42429,
+                limits=[TokenLimit(token="0x" + "cc" * 20, limit=1000, period=3600)],
+            )
+
+    def test_accepts_zero_period_limit(self):
+        auth = KeyAuthorization(
+            key_id="0x" + "bb" * 20,
+            chain_id=42429,
+            limits=[TokenLimit(token="0x" + "cc" * 20, limit=1000, period=0)],
+        )
+        assert auth.limits is not None

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -6,7 +6,7 @@ import pytest
 from eth_account import Account
 from eth_utils import to_bytes
 
-from pytempo import Call, CallScope, SelectorRule, TempoTransaction
+from pytempo import Call, CallScope, KeyRestrictions, SelectorRule, TempoTransaction
 from pytempo.contracts import ALPHA_USD
 from pytempo.contracts.account_keychain import AccountKeychain
 from pytempo.contracts.addresses import ACCOUNT_KEYCHAIN_ADDRESS
@@ -943,3 +943,119 @@ class TestCreateKeyAuthorizationCompat:
             limits=(TokenLimit(token="0x" + "c" * 40, limit=1000),),
         )
         assert via_wrapper.rlp_encode() == via_direct.rlp_encode()
+
+
+# ---------------------------------------------------------------------------
+# KeyRestrictions introspection
+# ---------------------------------------------------------------------------
+
+_TRANSFER_SELECTOR = bytes.fromhex("a9059cbb")
+
+
+class TestKeyRestrictionsIsUnrestricted:
+    """Tests for KeyRestrictions.is_unrestricted."""
+
+    def test_default_is_unrestricted(self):
+        r = KeyRestrictions()
+        assert r.is_unrestricted()
+
+    def test_with_scopes_is_not_unrestricted(self):
+        scope = CallScope.unrestricted(target="0x" + "aa" * 20)
+        r = KeyRestrictions(allowed_calls=[scope])
+        assert not r.is_unrestricted()
+
+    def test_empty_scopes_is_not_unrestricted(self):
+        r = KeyRestrictions(allowed_calls=[])
+        assert not r.is_unrestricted()
+
+
+class TestKeyRestrictionsIsCallAllowed:
+    """Tests mirroring tempo_alloy::KeyRestrictions::is_call_allowed."""
+
+    def test_unrestricted_allows_everything(self):
+        r = KeyRestrictions()
+        target = "0x" + "22" * 20
+        assert r.is_call_allowed(target)
+        assert r.is_call_allowed(target, b"\xaa\xbb\xcc\xdd")
+
+    def test_empty_scopes_denies_all(self):
+        r = KeyRestrictions(allowed_calls=[])
+        target = "0x" + "22" * 20
+        assert not r.is_call_allowed(target, b"\xaa\xbb\xcc\xdd")
+
+    def test_target_not_in_scope(self):
+        token = ALPHA_USD
+        other = "0x" + "33" * 20
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.unrestricted(target=token)],
+        )
+        assert not r.is_call_allowed(other, b"\xaa\xbb\xcc\xdd")
+
+    def test_no_selector_rules_allows_any_call(self):
+        target = "0x" + "aa" * 20
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.unrestricted(target=target)],
+        )
+        assert r.is_call_allowed(target, b"\xaa\xbb\xcc\xdd")
+        assert r.is_call_allowed(target)
+
+    def test_selector_match(self):
+        target = "0x" + "aa" * 20
+        sel = bytes.fromhex("aabbccdd")
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.with_selector(target=target, selector=sel)],
+        )
+        assert r.is_call_allowed(target, b"\xaa\xbb\xcc\xdd")
+        assert not r.is_call_allowed(target, b"\x11\x22\x33\x44")
+        assert not r.is_call_allowed(target, b"\xaa\xbb")
+
+    def test_transfer_with_recipients(self):
+        token = ALPHA_USD
+        allowed = "0x" + "44" * 20
+
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.transfer(target=token, recipients=[allowed])],
+        )
+
+        # Valid transfer calldata with allowed recipient
+        input_ok = bytearray()
+        input_ok.extend(_TRANSFER_SELECTOR)
+        input_ok.extend(b"\x00" * 12)
+        input_ok.extend(bytes.fromhex("44" * 20))
+        input_ok.extend(b"\x00" * 32)
+        assert r.is_call_allowed(token, bytes(input_ok))
+
+        # Same selector but denied recipient
+        input_bad = bytearray()
+        input_bad.extend(_TRANSFER_SELECTOR)
+        input_bad.extend(b"\x00" * 12)
+        input_bad.extend(bytes.fromhex("55" * 20))
+        input_bad.extend(b"\x00" * 32)
+        assert not r.is_call_allowed(token, bytes(input_bad))
+
+    def test_recipient_word_too_short(self):
+        token = ALPHA_USD
+        allowed = "0x" + "44" * 20
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.transfer(target=token, recipients=[allowed])],
+        )
+        # Selector only, no recipient word
+        assert not r.is_call_allowed(token, _TRANSFER_SELECTOR)
+
+    def test_no_recipients_allows_any(self):
+        token = ALPHA_USD
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.transfer(target=token, recipients=[])],
+        )
+
+        input_data = bytearray()
+        input_data.extend(_TRANSFER_SELECTOR)
+        input_data.extend(b"\x00" * 12)
+        input_data.extend(bytes.fromhex("99" * 20))
+        input_data.extend(b"\x00" * 32)
+        assert r.is_call_allowed(token, bytes(input_data))
+
+    def test_frozen(self):
+        r = KeyRestrictions()
+        with pytest.raises(AttributeError):
+            r.allowed_calls = []  # type: ignore[misc]

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -860,8 +860,84 @@ class TestSetAndRemoveAllowedCalls:
         assert call.data is not None
 
 
+class TestAuthorizeKeyWithRestrictions:
+    """Tests for authorize_key with KeyRestrictions."""
+
+    def test_basic_restrictions(self):
+        r = KeyRestrictions(expiry=2**64 - 1)
+        call = AccountKeychain.authorize_key(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=r,
+        )
+        assert call.data is not None
+
+    def test_restrictions_with_call_scopes(self):
+        scope = CallScope.transfer(target=ALPHA_USD)
+        r = KeyRestrictions(
+            expiry=2**64 - 1,
+            allowed_calls=[scope],
+        )
+        call = AccountKeychain.authorize_key(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=r,
+        )
+        assert call.data is not None
+
+    def test_restrictions_with_limits(self):
+        r = KeyRestrictions(
+            expiry=1893456000,
+            limits=[TokenLimit(token="0x" + "cc" * 20, limit=1000)],
+        )
+        call = AccountKeychain.authorize_key(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=r,
+        )
+        assert call.data is not None
+
+    def test_rejects_mixed_restrictions_and_legacy_params(self):
+        r = KeyRestrictions(expiry=2**64 - 1)
+        with pytest.raises(ValueError, match="cannot combine"):
+            AccountKeychain.authorize_key(
+                key_id="0x" + "11" * 20,
+                signature_type=SignatureType.SECP256K1,
+                restrictions=r,
+                expiry=999,
+            )
+
+    def test_legacy_with_restrictions_rejects_call_scopes(self):
+        scope = CallScope.transfer(target=ALPHA_USD)
+        r = KeyRestrictions(allowed_calls=[scope])
+        with pytest.raises(ValueError, match="call restrictions"):
+            AccountKeychain.authorize_key(
+                key_id="0x" + "11" * 20,
+                signature_type=SignatureType.SECP256K1,
+                restrictions=r,
+                legacy=True,
+            )
+
+    def test_default_restrictions_produces_valid_call(self):
+        call = AccountKeychain.authorize_key(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=KeyRestrictions(),
+        )
+        assert call.data is not None
+
+    def test_no_calls_restrictions(self):
+        r = KeyRestrictions.no_calls()
+        call = AccountKeychain.authorize_key(
+            key_id="0x" + "11" * 20,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=r,
+        )
+        assert call.data is not None
+
+
 class TestAuthorizeKeyGuards:
-    """Tests for authorize_key argument validation."""
+    """Tests for authorize_key deprecated param validation."""
 
     def test_rejects_allowed_calls_with_allow_any_calls_true(self):
         scope = CallScope.transfer(target=ALPHA_USD)
@@ -875,7 +951,7 @@ class TestAuthorizeKeyGuards:
 
     def test_rejects_legacy_with_call_restrictions(self):
         scope = CallScope.transfer(target=ALPHA_USD)
-        with pytest.raises(ValueError, match="legacy"):
+        with pytest.raises(ValueError, match="legacy|call restrictions"):
             AccountKeychain.authorize_key(
                 key_id="0x" + "11" * 20,
                 signature_type=SignatureType.SECP256K1,


### PR DESCRIPTION
Adds `KeyRestrictions` and integrates it into the SDK's access-key type system.

## Changes

- `KeyRestrictions` frozen attrs class with `expiry`, `limits`, `allowed_calls`
- `is_unrestricted()` and `is_call_allowed(target, input_data)` — full selector + recipient matching
- `to_abi_tuple()` — ABI encoding for the `authorizeKey` precompile
- `no_spending()` / `no_calls()` convenience constructors
- `TokenLimit.period` field with uint64 validation
- `AccountKeychain.authorize_key()` now requires `restrictions=KeyRestrictions(...)` (breaking — old individual params removed)
- `AccountKeychain.authorize_key_legacy()` convenience method
- `KeyAuthorization` rejects periodic limits with a clear error (inline auth doesn't support them)
- Updated docs and integration tests

Prompted by: rusowsky