### PR TITLE
chore: downgrade release from major to minor

### DIFF
--- a/.changelog/calm-lakes-wink.md
+++ b/.changelog/calm-lakes-wink.md
@@ -1,5 +1,5 @@
 ---
-pytempo: major
+pytempo: minor
 ---
 
 Added TIP-1011 `authorizeKey` support with `KeyRestrictions` struct (T3+) as the new `authorize_key` method, and renamed the previous flat-params variant to `authorize_key_legacy` for pre-T3 compatibility. Updated `IAccountKeychain` ABI with the new function signature and `LegacyAuthorizeKeySelectorChanged` error.


### PR DESCRIPTION
Changes the changelog entry from `major` to `minor` so the next release is v0.5.0 instead of v1.0.0.

Once merged, the changelogs workflow will re-generate [PR #42](https://github.com/tempoxyz/pytempo/pull/42) with v0.5.0.

Prompted by: rusowsky