### PR TITLE
fix(ci): remove persist-credentials: false to fix publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
 
       - uses: wevm/changelogs@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # master
         with:


### PR DESCRIPTION
The publish workflow fails at `git push --follow-tags` with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

`persist-credentials: false` strips the GITHUB_TOKEN from git config, so changelogs can't push tags back. Removing it lets the default credential persist through the job.

Prompted by: rusowsky