### PR TITLE
chore: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      actions-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -13,3 +18,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pip-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Group minor and patch version updates per ecosystem into single PRs to reduce PR noise.

- Minor/patch bumps are batched into **one PR per ecosystem** per week
- **Major** version bumps still get individual PRs for careful review
- **Security** updates (`applies-to: version-updates`) are excluded from grouping and arrive as individual PRs for urgent review