### PR TITLE
ci: use OIDC trusted publishing for PyPI releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,48 +6,26 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: write
       pull-requests: write
-    outputs:
-      published: ${{ steps.changelogs.outputs.published }}
+      id-token: write   # required for PyPI Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
-      - uses: wevm/changelogs@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # master
-        id: changelogs
+      - uses: wevm/changelogs@de0250123a1d70a2b64a458bd5efcf313986df7a # OIDC trusted publishing
         with:
           ecosystem: python
           python-version: '3.12'
           conventional-commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish to PyPI
-    needs: release
-    if: needs.release.outputs.published == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    environment: pypi
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-        with:
-          version: "0.7.12"
-
-      - run: uv python install 3.12
-
-      - run: uv build
-
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Problem

Release commits since `v0.5.0` have failed with `403 Forbidden` from PyPI:

```
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
```

The `release` job ran `wevm/changelogs`, which did its own `twine upload` with no `pypi-token` input, so twine had no auth and PyPI rejected it. The separate `publish` job using `pypa/gh-action-pypi-publish` never ran because `release` errored first.

## Fix

`wevm/changelogs` now natively supports PyPI Trusted Publishing (OIDC) as of [tempoxyz/changelogs#116](https://github.com/tempoxyz/changelogs/pull/116). When `pypi-token` is empty and the workflow has `id-token: write`, it mints a short-lived PyPI API token at PyPI's `_/oidc/mint-token` endpoint and uses it for the upload.

Collapse the two-job workflow into a single `release` job that:
- Pins `wevm/changelogs` to the merge commit with OIDC support (`de02501`).
- Grants `id-token: write` and `environment: pypi` so the OIDC mint flow matches the registered Trusted Publisher entry on PyPI.

## Setup

The PyPI Trusted Publisher entry on `pytempo` should match:
- Owner: `tempoxyz`
- Repository: `pytempo`
- Workflow: `publish.yml`
- Environment: `pypi`

No new secrets are needed — the `PYPI_TOKEN` secret can be removed after this lands.
