### PR TITLE
chore: T5 hardfork update

### DIFF
--- a/.changelog/t5-hardfork-bindings.md
+++ b/.changelog/t5-hardfork-bindings.md
@@ -1,0 +1,5 @@
+---
+pytempo: minor
+---
+
+Add T5 hardfork contract bindings, including refreshed ABIs, AccountKeychain helpers, TIP20 role/admin/reward controls, and stricter ABI response decoding.

--- a/pytempo/contracts/__init__.py
+++ b/pytempo/contracts/__init__.py
@@ -32,6 +32,7 @@ from .abis import (
     NONCE_ABI,
     STABLECOIN_DEX_ABI,
     TIP20_ABI,
+    TIP20_ROLES_AUTH_ABI,
 )
 from .account_keychain import AccountKeychain
 from .addresses import (
@@ -64,6 +65,7 @@ __all__ = [
     "Nonce",
     # ABIs
     "TIP20_ABI",
+    "TIP20_ROLES_AUTH_ABI",
     "ACCOUNT_KEYCHAIN_ABI",
     "STABLECOIN_DEX_ABI",
     "FEE_MANAGER_ABI",

--- a/pytempo/contracts/_decode.py
+++ b/pytempo/contracts/_decode.py
@@ -1,0 +1,44 @@
+"""Internal helpers for decoding fixed-width ABI return values."""
+
+from eth_utils import to_checksum_address
+
+
+def decode_word(result: bytes, name: str) -> bytes:
+    """Decode a single ABI word, rejecting empty or malformed responses."""
+    raw = bytes(result)
+    if len(raw) != 32:
+        raise ValueError(
+            f"{name} result wrong length, expected 32 bytes, got {len(raw)}"
+        )
+    return raw
+
+
+def decode_uint(result: bytes, name: str) -> int:
+    """Decode a single uint ABI word."""
+    return int.from_bytes(decode_word(result, name), "big")
+
+
+def decode_u64(result: bytes, name: str) -> int:
+    """Decode a uint64 encoded in a single ABI word."""
+    value = decode_uint(result, name)
+    if value > 2**64 - 1:
+        raise ValueError(f"{name} result exceeds uint64, got {value}")
+    return value
+
+
+def decode_bool(result: bytes, name: str) -> bool:
+    """Decode a single bool ABI word, rejecting non-canonical values."""
+    value = decode_uint(result, name)
+    if value not in (0, 1):
+        raise ValueError(f"{name} result must be ABI bool 0 or 1, got {value}")
+    return bool(value)
+
+
+def decode_address(result: bytes, name: str) -> str:
+    """Decode an address encoded in a single ABI word."""
+    return to_checksum_address(decode_word(result, name)[-20:])
+
+
+def decode_hash32(result: bytes, name: str) -> bytes:
+    """Decode a bytes32 ABI word."""
+    return decode_word(result, name)

--- a/pytempo/contracts/abis/IAccountKeychain.json
+++ b/pytempo/contracts/abis/IAccountKeychain.json
@@ -16,6 +16,16 @@
   },
   {
     "inputs": [],
+    "name": "InvalidKeyAuthorizationWitness",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidKeyId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidSignatureType",
     "type": "error"
   },
@@ -32,6 +42,11 @@
   {
     "inputs": [],
     "name": "KeyAlreadyRevoked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "KeyAuthorizationWitnessAlreadyBurned",
     "type": "error"
   },
   {
@@ -137,6 +152,63 @@
         "internalType": "address",
         "name": "publicKey",
         "type": "address"
+      }
+    ],
+    "name": "AdminKeyAuthorized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "KeyAuthorizationWitness",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "KeyAuthorizationWitnessBurned",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "publicKey",
+        "type": "address"
       },
       {
         "indexed": false,
@@ -203,6 +275,29 @@
     ],
     "name": "SpendingLimitUpdated",
     "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "keyId",
+        "type": "address"
+      },
+      {
+        "internalType": "enum IAccountKeychain.SignatureType",
+        "name": "signatureType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "authorizeAdminKey",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
     "inputs": [
@@ -336,6 +431,115 @@
       }
     ],
     "name": "authorizeKey",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "keyId",
+        "type": "address"
+      },
+      {
+        "internalType": "enum IAccountKeychain.SignatureType",
+        "name": "signatureType",
+        "type": "uint8"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint64",
+            "name": "expiry",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "enforceLimits",
+            "type": "bool"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint64",
+                "name": "period",
+                "type": "uint64"
+              }
+            ],
+            "internalType": "struct IAccountKeychain.TokenLimit[]",
+            "name": "limits",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "bool",
+            "name": "allowAnyCalls",
+            "type": "bool"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "bytes4",
+                    "name": "selector",
+                    "type": "bytes4"
+                  },
+                  {
+                    "internalType": "address[]",
+                    "name": "recipients",
+                    "type": "address[]"
+                  }
+                ],
+                "internalType": "struct IAccountKeychain.SelectorRule[]",
+                "name": "selectorRules",
+                "type": "tuple[]"
+              }
+            ],
+            "internalType": "struct IAccountKeychain.CallScope[]",
+            "name": "allowedCalls",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct IAccountKeychain.KeyRestrictions",
+        "name": "config",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "authorizeKey",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "burnKeyAuthorizationWitness",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -515,6 +719,54 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "keyId",
+        "type": "address"
+      }
+    ],
+    "name": "isAdminKey",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "witness",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isKeyAuthorizationWitnessBurned",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "burned",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",

--- a/pytempo/contracts/abis/IFeeAMM.json
+++ b/pytempo/contracts/abis/IFeeAMM.json
@@ -26,11 +26,6 @@
   },
   {
     "inputs": [],
-    "name": "InvalidCurrency",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "InvalidSwapCalculation",
     "type": "error"
   },

--- a/pytempo/contracts/abis/IFeeManager.json
+++ b/pytempo/contracts/abis/IFeeManager.json
@@ -1,12 +1,22 @@
 [
   {
     "inputs": [],
+    "name": "CannotChangeWithinBlock",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "DivisionByZero",
     "type": "error"
   },
   {
     "inputs": [],
     "name": "IdenticalAddresses",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientFeeTokenBalance",
     "type": "error"
   },
   {
@@ -22,11 +32,6 @@
   {
     "inputs": [],
     "name": "InvalidAmount",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidCurrency",
     "type": "error"
   },
   {
@@ -589,7 +594,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "user",
         "type": "address"
       }
     ],
@@ -608,7 +613,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "validator",
         "type": "address"
       }
     ],

--- a/pytempo/contracts/abis/INonce.json
+++ b/pytempo/contracts/abis/INonce.json
@@ -1,6 +1,21 @@
 [
   {
     "inputs": [],
+    "name": "ExpiringNonceReplay",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExpiringNonceSetFull",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidExpiringNonceExpiry",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidNonceKey",
     "type": "error"
   },

--- a/pytempo/contracts/abis/IStablecoinDEX.json
+++ b/pytempo/contracts/abis/IStablecoinDEX.json
@@ -99,6 +99,31 @@
         "internalType": "uint128",
         "name": "orderId",
         "type": "uint128"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "reason",
+        "type": "bytes4"
+      }
+    ],
+    "name": "FlipFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "orderId",
+        "type": "uint128"
       }
     ],
     "name": "OrderCancelled",
@@ -139,6 +164,55 @@
       }
     ],
     "name": "OrderFilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "orderId",
+        "type": "uint128"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isBid",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "int16",
+        "name": "tick",
+        "type": "int16"
+      },
+      {
+        "indexed": false,
+        "internalType": "int16",
+        "name": "flipTick",
+        "type": "int16"
+      }
+    ],
+    "name": "OrderFlipped",
     "type": "event"
   },
   {
@@ -231,7 +305,7 @@
         "type": "uint32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -244,7 +318,7 @@
         "type": "int16"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -257,7 +331,7 @@
         "type": "uint128"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -270,7 +344,7 @@
         "type": "uint32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -283,7 +357,7 @@
         "type": "int16"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -296,7 +370,7 @@
         "type": "uint32"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -309,7 +383,7 @@
         "type": "int16"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/pytempo/contracts/abis/ITIP20.json
+++ b/pytempo/contracts/abis/ITIP20.json
@@ -37,12 +37,17 @@
   },
   {
     "inputs": [],
-    "name": "InvalidBaseToken",
+    "name": "InvalidCurrency",
     "type": "error"
   },
   {
     "inputs": [],
-    "name": "InvalidCurrency",
+    "name": "InvalidLogoURI",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPayload",
     "type": "error"
   },
   {
@@ -77,6 +82,11 @@
   },
   {
     "inputs": [],
+    "name": "LogoURITooLong",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NoOptedInSupply",
     "type": "error"
   },
@@ -98,6 +108,16 @@
   {
     "inputs": [],
     "name": "SupplyCapExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Uninitialized",
     "type": "error"
   },
   {
@@ -161,6 +181,25 @@
       }
     ],
     "name": "BurnBlocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newLogoURI",
+        "type": "string"
+      }
+    ],
+    "name": "LogoURIUpdated",
     "type": "event"
   },
   {
@@ -635,9 +674,9 @@
     "name": "getPendingRewards",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",
@@ -651,6 +690,19 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "logoURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
       }
     ],
     "stateMutability": "view",
@@ -834,6 +886,19 @@
   {
     "inputs": [
       {
+        "internalType": "string",
+        "name": "newLogoURI",
+        "type": "string"
+      }
+    ],
+    "name": "setLogoURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "contract ITIP20",
         "name": "newQuoteToken",
         "type": "address"
@@ -897,35 +962,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "from",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "systemTransferFrom",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "totalSupply",
     "outputs": [
@@ -959,47 +995,6 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "refund",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "actualUsed",
-        "type": "uint256"
-      }
-    ],
-    "name": "transferFeePostTx",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "from",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "transferFeePreTx",
-    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/pytempo/contracts/abis/ITIP20RolesAuth.json
+++ b/pytempo/contracts/abis/ITIP20RolesAuth.json
@@ -1,0 +1,173 @@
+[
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleAdminUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "hasRole",
+        "type": "bool"
+      }
+    ],
+    "name": "RoleMembershipUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "adminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setRoleAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/pytempo/contracts/abis/__init__.py
+++ b/pytempo/contracts/abis/__init__.py
@@ -12,6 +12,7 @@ def _load(name: str) -> list:
 
 
 TIP20_ABI = _load("ITIP20")
+TIP20_ROLES_AUTH_ABI = _load("ITIP20RolesAuth")
 ACCOUNT_KEYCHAIN_ABI = _load("IAccountKeychain")
 STABLECOIN_DEX_ABI = _load("IStablecoinDEX")
 FEE_MANAGER_ABI = _load("IFeeManager")

--- a/pytempo/contracts/account_keychain.py
+++ b/pytempo/contracts/account_keychain.py
@@ -19,16 +19,26 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from eth_utils import to_checksum_address
-
 from pytempo.keychain import CallScope, KeyRestrictions, SignatureType
 from pytempo.models import Call
+from pytempo.types import BytesLike, as_hash32
 
+from ._decode import decode_address, decode_bool, decode_u64, decode_uint
 from ._encode import encode_calldata
 from .abis import ACCOUNT_KEYCHAIN_ABI
 from .addresses import ACCOUNT_KEYCHAIN_ADDRESS
 
 _ABI = ACCOUNT_KEYCHAIN_ABI
+
+
+def _hash32(value: BytesLike) -> bytes:
+    return bytes(as_hash32(value))
+
+
+def _require_addresses(**values: str) -> None:
+    missing = ", ".join(name for name, value in values.items() if not value)
+    if missing:
+        raise ValueError(f"{missing} required")
 
 
 class AccountKeychain:
@@ -46,6 +56,7 @@ class AccountKeychain:
         signature_type: SignatureType,
         restrictions: KeyRestrictions,
         legacy: bool = False,
+        witness: BytesLike | None = None,
     ) -> Call:
         """Build an ``authorizeKey`` call.
 
@@ -55,8 +66,11 @@ class AccountKeychain:
             restrictions: Key restrictions (expiry, limits, call scopes).
             legacy: Use pre-T3 flat-parameter encoding. Pass ``True``
                 until T3 is activated, then remove this argument.
+            witness: Optional T5 key-authorization witness.
         """
         if legacy:
+            if witness is not None:
+                raise ValueError("legacy=True does not support witnesses")
             if restrictions.allowed_calls is not None:
                 raise ValueError("legacy=True does not support call restrictions")
             if restrictions.limits and any(
@@ -83,12 +97,29 @@ class AccountKeychain:
                 ],
             )
         else:
+            args = [key_id, int(signature_type), restrictions.to_abi_tuple()]
+            if witness is not None:
+                args.append(_hash32(witness))
             data = encode_calldata(
                 _ABI,
                 "authorizeKey",
-                [key_id, int(signature_type), restrictions.to_abi_tuple()],
+                args,
             )
 
+        return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)
+
+    @staticmethod
+    def authorize_admin_key(
+        *,
+        key_id: str,
+        signature_type: SignatureType,
+        witness: BytesLike,
+    ) -> Call:
+        """Build an ``authorizeAdminKey(address,uint8,bytes32)`` call."""
+        _require_addresses(key_id=key_id)
+        data = encode_calldata(
+            _ABI, "authorizeAdminKey", [key_id, int(signature_type), _hash32(witness)]
+        )
         return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)
 
     @staticmethod
@@ -114,6 +145,12 @@ class AccountKeychain:
     def revoke_key(*, key_id: str) -> Call:
         """Build a ``revokeKey(address)`` call."""
         data = encode_calldata(_ABI, "revokeKey", [key_id])
+        return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)
+
+    @staticmethod
+    def burn_key_authorization_witness(*, witness: BytesLike) -> Call:
+        """Build a ``burnKeyAuthorizationWitness(bytes32)`` call."""
+        data = encode_calldata(_ABI, "burnKeyAuthorizationWitness", [_hash32(witness)])
         return Call.create(to=ACCOUNT_KEYCHAIN_ADDRESS, data=data)
 
     @staticmethod
@@ -172,8 +209,7 @@ class AccountKeychain:
         Raises:
             ValueError: If any address parameter is empty or result is wrong length.
         """
-        if not account_address or not key_id:
-            raise ValueError("account_address and key_id are required")
+        _require_addresses(account_address=account_address, key_id=key_id)
 
         call_data = encode_calldata(_ABI, "getKey", [account_address, key_id])
         result = bytes(w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data}))
@@ -187,10 +223,10 @@ class AccountKeychain:
 
         return {
             "signature_type": int.from_bytes(words[0], "big"),
-            "key_id": to_checksum_address(words[1][-20:]),
+            "key_id": decode_address(words[1], "getKey.keyId"),
             "expiry": int.from_bytes(words[2], "big"),
-            "enforce_limits": bool(int.from_bytes(words[3], "big")),
-            "is_revoked": bool(int.from_bytes(words[4], "big")),
+            "enforce_limits": decode_bool(words[3], "getKey.enforceLimits"),
+            "is_revoked": decode_bool(words[4], "getKey.isRevoked"),
         }
 
     @staticmethod
@@ -215,8 +251,11 @@ class AccountKeychain:
         Raises:
             ValueError: If any address parameter is empty.
         """
-        if not account_address or not key_id or not token_address:
-            raise ValueError("account_address, key_id, and token_address are required")
+        _require_addresses(
+            account_address=account_address,
+            key_id=key_id,
+            token_address=token_address,
+        )
 
         call_data = encode_calldata(
             _ABI,
@@ -224,4 +263,73 @@ class AccountKeychain:
             [account_address, key_id, token_address],
         )
         result = w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data})
-        return int.from_bytes(result, "big")
+        return decode_uint(result, "getRemainingLimit")
+
+    @staticmethod
+    def get_remaining_limit_with_period(
+        w3,
+        *,
+        account_address: str,
+        key_id: str,
+        token_address: str,
+    ) -> dict:
+        """Query remaining spending limit and current period end for an access key."""
+        _require_addresses(
+            account_address=account_address,
+            key_id=key_id,
+            token_address=token_address,
+        )
+
+        call_data = encode_calldata(
+            _ABI,
+            "getRemainingLimitWithPeriod",
+            [account_address, key_id, token_address],
+        )
+        result = bytes(w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data}))
+        if len(result) != 64:
+            raise ValueError(
+                "getRemainingLimitWithPeriod result wrong length, "
+                f"expected 64 bytes, got {len(result)}"
+            )
+        return {
+            "remaining": decode_uint(
+                result[:32], "getRemainingLimitWithPeriod.remaining"
+            ),
+            "period_end": decode_u64(
+                result[32:], "getRemainingLimitWithPeriod.periodEnd"
+            ),
+        }
+
+    @staticmethod
+    def get_transaction_key(w3) -> str:
+        """Query the active transaction key from the AccountKeychain precompile."""
+        call_data = encode_calldata(_ABI, "getTransactionKey", [])
+        result = w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data})
+        return decode_address(result, "getTransactionKey")
+
+    @staticmethod
+    def is_admin_key(w3, *, account_address: str, key_id: str) -> bool:
+        """Query whether ``key_id`` is an admin key for ``account_address``."""
+        _require_addresses(account_address=account_address, key_id=key_id)
+
+        call_data = encode_calldata(_ABI, "isAdminKey", [account_address, key_id])
+        result = w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data})
+        return decode_bool(result, "isAdminKey")
+
+    @staticmethod
+    def is_key_authorization_witness_burned(
+        w3,
+        *,
+        account_address: str,
+        witness: BytesLike,
+    ) -> bool:
+        """Query whether a key-authorization witness has been burned."""
+        _require_addresses(account_address=account_address)
+
+        call_data = encode_calldata(
+            _ABI,
+            "isKeyAuthorizationWitnessBurned",
+            [account_address, _hash32(witness)],
+        )
+        result = w3.eth.call({"to": ACCOUNT_KEYCHAIN_ADDRESS, "data": call_data})
+        return decode_bool(result, "isKeyAuthorizationWitnessBurned")

--- a/pytempo/contracts/nonce.py
+++ b/pytempo/contracts/nonce.py
@@ -10,6 +10,7 @@ Query nonce values for Tempo's 2D nonce system::
     nonce = Nonce.get_nonce(w3, account="0xAccount...", nonce_key=0)
 """
 
+from ._decode import decode_u64
 from ._encode import encode_calldata
 from .abis import NONCE_ABI
 from .addresses import NONCE_ADDRESS
@@ -39,4 +40,4 @@ class Nonce:
         """
         call_data = encode_calldata(_ABI, "getNonce", [account, nonce_key])
         result = w3.eth.call({"to": NONCE_ADDRESS, "data": call_data})
-        return int.from_bytes(result, "big")
+        return decode_u64(result, "getNonce")

--- a/pytempo/contracts/tip20.py
+++ b/pytempo/contracts/tip20.py
@@ -11,11 +11,29 @@ Returns :class:`~pytempo.Call` objects ready to use in a
 """
 
 from pytempo.models import Call
+from pytempo.types import BytesLike, as_hash32
 
+from ._decode import decode_bool, decode_hash32
 from ._encode import encode_calldata
-from .abis import TIP20_ABI
+from .abis import TIP20_ABI, TIP20_ROLES_AUTH_ABI
 
 _ABI = TIP20_ABI
+_ROLES_ABI = TIP20_ROLES_AUTH_ABI
+
+
+def _memo32(memo: bytes) -> bytes:
+    if len(memo) > 32:
+        raise ValueError("memo must be at most 32 bytes")
+    return memo.ljust(32, b"\x00")
+
+
+def _role32(role: BytesLike) -> bytes:
+    return bytes(as_hash32(role))
+
+
+def _require_account(account: str) -> None:
+    if not account:
+        raise ValueError("account required")
 
 
 class TIP20:
@@ -40,10 +58,7 @@ class TIP20:
 
         *memo* is right-padded to 32 bytes if shorter.
         """
-        if len(memo) > 32:
-            raise ValueError("memo must be at most 32 bytes")
-        padded = memo.ljust(32, b"\x00")
-        data = encode_calldata(_ABI, "transferWithMemo", [to, amount, padded])
+        data = encode_calldata(_ABI, "transferWithMemo", [to, amount, _memo32(memo)])
         return Call.create(to=self.token, data=data)
 
     def transfer_from(self, *, sender: str, to: str, amount: int) -> Call:
@@ -55,11 +70,8 @@ class TIP20:
         self, *, sender: str, to: str, amount: int, memo: bytes
     ) -> Call:
         """Build a ``transferFromWithMemo(address,address,uint256,bytes32)`` call."""
-        if len(memo) > 32:
-            raise ValueError("memo must be at most 32 bytes")
-        padded = memo.ljust(32, b"\x00")
         data = encode_calldata(
-            _ABI, "transferFromWithMemo", [sender, to, amount, padded]
+            _ABI, "transferFromWithMemo", [sender, to, amount, _memo32(memo)]
         )
         return Call.create(to=self.token, data=data)
 
@@ -75,10 +87,7 @@ class TIP20:
 
     def mint_with_memo(self, *, to: str, amount: int, memo: bytes) -> Call:
         """Build a ``mintWithMemo(address,uint256,bytes32)`` call (issuer only)."""
-        if len(memo) > 32:
-            raise ValueError("memo must be at most 32 bytes")
-        padded = memo.ljust(32, b"\x00")
-        data = encode_calldata(_ABI, "mintWithMemo", [to, amount, padded])
+        data = encode_calldata(_ABI, "mintWithMemo", [to, amount, _memo32(memo)])
         return Call.create(to=self.token, data=data)
 
     def burn(self, *, amount: int) -> Call:
@@ -88,10 +97,62 @@ class TIP20:
 
     def burn_with_memo(self, *, amount: int, memo: bytes) -> Call:
         """Build a ``burnWithMemo(uint256,bytes32)`` call."""
-        if len(memo) > 32:
-            raise ValueError("memo must be at most 32 bytes")
-        padded = memo.ljust(32, b"\x00")
-        data = encode_calldata(_ABI, "burnWithMemo", [amount, padded])
+        data = encode_calldata(_ABI, "burnWithMemo", [amount, _memo32(memo)])
+        return Call.create(to=self.token, data=data)
+
+    def burn_blocked(self, *, sender: str, amount: int) -> Call:
+        """Build a ``burnBlocked(address,uint256)`` call."""
+        data = encode_calldata(_ABI, "burnBlocked", [sender, amount])
+        return Call.create(to=self.token, data=data)
+
+    def change_transfer_policy_id(self, *, new_policy_id: int) -> Call:
+        """Build a ``changeTransferPolicyId(uint64)`` call."""
+        data = encode_calldata(_ABI, "changeTransferPolicyId", [new_policy_id])
+        return Call.create(to=self.token, data=data)
+
+    def claim_rewards(self) -> Call:
+        """Build a ``claimRewards()`` call."""
+        data = encode_calldata(_ABI, "claimRewards", [])
+        return Call.create(to=self.token, data=data)
+
+    def complete_quote_token_update(self) -> Call:
+        """Build a ``completeQuoteTokenUpdate()`` call."""
+        data = encode_calldata(_ABI, "completeQuoteTokenUpdate", [])
+        return Call.create(to=self.token, data=data)
+
+    def distribute_reward(self, *, amount: int) -> Call:
+        """Build a ``distributeReward(uint256)`` call."""
+        data = encode_calldata(_ABI, "distributeReward", [amount])
+        return Call.create(to=self.token, data=data)
+
+    def pause(self) -> Call:
+        """Build a ``pause()`` call."""
+        data = encode_calldata(_ABI, "pause", [])
+        return Call.create(to=self.token, data=data)
+
+    def set_logo_uri(self, *, logo_uri: str) -> Call:
+        """Build a ``setLogoURI(string)`` call."""
+        data = encode_calldata(_ABI, "setLogoURI", [logo_uri])
+        return Call.create(to=self.token, data=data)
+
+    def set_next_quote_token(self, *, new_quote_token: str) -> Call:
+        """Build a ``setNextQuoteToken(address)`` call."""
+        data = encode_calldata(_ABI, "setNextQuoteToken", [new_quote_token])
+        return Call.create(to=self.token, data=data)
+
+    def set_reward_recipient(self, *, new_reward_recipient: str) -> Call:
+        """Build a ``setRewardRecipient(address)`` call."""
+        data = encode_calldata(_ABI, "setRewardRecipient", [new_reward_recipient])
+        return Call.create(to=self.token, data=data)
+
+    def set_supply_cap(self, *, new_supply_cap: int) -> Call:
+        """Build a ``setSupplyCap(uint256)`` call."""
+        data = encode_calldata(_ABI, "setSupplyCap", [new_supply_cap])
+        return Call.create(to=self.token, data=data)
+
+    def unpause(self) -> Call:
+        """Build an ``unpause()`` call."""
+        data = encode_calldata(_ABI, "unpause", [])
         return Call.create(to=self.token, data=data)
 
     def permit(
@@ -114,3 +175,59 @@ class TIP20:
             _ABI, "permit", [owner, spender, value, deadline, v, r, s]
         )
         return Call.create(to=self.token, data=data)
+
+    def grant_role(self, *, role: BytesLike, account: str) -> Call:
+        """Build a ``grantRole(bytes32,address)`` call."""
+        data = encode_calldata(_ROLES_ABI, "grantRole", [_role32(role), account])
+        return Call.create(to=self.token, data=data)
+
+    def revoke_role(self, *, role: BytesLike, account: str) -> Call:
+        """Build a ``revokeRole(bytes32,address)`` call."""
+        data = encode_calldata(_ROLES_ABI, "revokeRole", [_role32(role), account])
+        return Call.create(to=self.token, data=data)
+
+    def renounce_role(self, *, role: BytesLike) -> Call:
+        """Build a ``renounceRole(bytes32)`` call."""
+        data = encode_calldata(_ROLES_ABI, "renounceRole", [_role32(role)])
+        return Call.create(to=self.token, data=data)
+
+    def set_role_admin(self, *, role: BytesLike, admin_role: BytesLike) -> Call:
+        """Build a ``setRoleAdmin(bytes32,bytes32)`` call."""
+        data = encode_calldata(
+            _ROLES_ABI, "setRoleAdmin", [_role32(role), _role32(admin_role)]
+        )
+        return Call.create(to=self.token, data=data)
+
+    def get_role_admin(self, w3, *, role: BytesLike) -> bytes:
+        """Query ``getRoleAdmin(bytes32)``."""
+        call_data = encode_calldata(_ROLES_ABI, "getRoleAdmin", [_role32(role)])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_hash32(result, "getRoleAdmin")
+
+    def has_role(self, w3, *, role: BytesLike, account: str) -> bool:
+        """Query ``hasRole(address,bytes32)``."""
+        _require_account(account)
+        call_data = encode_calldata(_ROLES_ABI, "hasRole", [account, _role32(role)])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_bool(result, "hasRole")
+
+    def burn_blocked_role(self, w3) -> bytes:
+        """Query ``BURN_BLOCKED_ROLE()``."""
+        return self._role_constant(w3, "BURN_BLOCKED_ROLE")
+
+    def issuer_role(self, w3) -> bytes:
+        """Query ``ISSUER_ROLE()``."""
+        return self._role_constant(w3, "ISSUER_ROLE")
+
+    def pause_role(self, w3) -> bytes:
+        """Query ``PAUSE_ROLE()``."""
+        return self._role_constant(w3, "PAUSE_ROLE")
+
+    def unpause_role(self, w3) -> bytes:
+        """Query ``UNPAUSE_ROLE()``."""
+        return self._role_constant(w3, "UNPAUSE_ROLE")
+
+    def _role_constant(self, w3, name: str) -> bytes:
+        call_data = encode_calldata(_ABI, name, [])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_hash32(result, name)

--- a/scripts/tempo_abis.sh
+++ b/scripts/tempo_abis.sh
@@ -18,7 +18,7 @@ case "${1:-}" in
 esac
 
 REPO="tempoxyz/tempo-std"
-INTERFACES=(ITIP20 IAccountKeychain IStablecoinDEX IFeeManager IFeeAMM INonce)
+INTERFACES=(ITIP20 ITIP20RolesAuth IAccountKeychain IStablecoinDEX IFeeManager IFeeAMM INonce)
 ABI_DIR="$(cd "$(dirname "$0")/.." && pwd)/pytempo/contracts/abis"
 
 WORK_DIR=$(mktemp -d)

--- a/tests/test_contract_bindings.py
+++ b/tests/test_contract_bindings.py
@@ -1,0 +1,214 @@
+"""Tests for typed contract call builders."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from eth_utils import function_signature_to_4byte_selector
+
+from pytempo import KeyRestrictions
+from pytempo.contracts import ALPHA_USD, BETA_USD, TIP20, TIP20_ROLES_AUTH_ABI, Nonce
+from pytempo.contracts.account_keychain import AccountKeychain
+from pytempo.contracts.addresses import ACCOUNT_KEYCHAIN_ADDRESS, NONCE_ADDRESS
+from pytempo.keychain import SignatureType
+
+RECIPIENT = "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
+ROLE = "0x" + "11" * 32
+WITNESS = "0x" + "33" * 32
+
+
+def _selector(signature: str) -> bytes:
+    return function_signature_to_4byte_selector(signature)
+
+
+def test_tip20_t5_builders_encode_expected_selectors():
+    token = TIP20(ALPHA_USD)
+
+    cases = [
+        (
+            token.burn_blocked(sender=RECIPIENT, amount=1),
+            "burnBlocked(address,uint256)",
+        ),
+        (
+            token.change_transfer_policy_id(new_policy_id=7),
+            "changeTransferPolicyId(uint64)",
+        ),
+        (token.claim_rewards(), "claimRewards()"),
+        (token.complete_quote_token_update(), "completeQuoteTokenUpdate()"),
+        (token.distribute_reward(amount=10), "distributeReward(uint256)"),
+        (token.pause(), "pause()"),
+        (
+            token.set_logo_uri(logo_uri="https://example.com/logo.png"),
+            "setLogoURI(string)",
+        ),
+        (
+            token.set_next_quote_token(new_quote_token=BETA_USD),
+            "setNextQuoteToken(address)",
+        ),
+        (
+            token.set_reward_recipient(new_reward_recipient=RECIPIENT),
+            "setRewardRecipient(address)",
+        ),
+        (token.set_supply_cap(new_supply_cap=1_000_000), "setSupplyCap(uint256)"),
+        (token.unpause(), "unpause()"),
+        (token.grant_role(role=ROLE, account=RECIPIENT), "grantRole(bytes32,address)"),
+        (
+            token.revoke_role(role=ROLE, account=RECIPIENT),
+            "revokeRole(bytes32,address)",
+        ),
+        (token.renounce_role(role=ROLE), "renounceRole(bytes32)"),
+        (
+            token.set_role_admin(role=ROLE, admin_role="0x" + "22" * 32),
+            "setRoleAdmin(bytes32,bytes32)",
+        ),
+    ]
+
+    for call, signature in cases:
+        assert call.to == bytes.fromhex(ALPHA_USD[2:])
+        assert call.data[:4] == _selector(signature)
+
+
+def test_tip20_roles_auth_abi_is_exported():
+    functions = {
+        entry["name"]
+        for entry in TIP20_ROLES_AUTH_ABI
+        if entry.get("type") == "function"
+    }
+
+    assert functions == {
+        "getRoleAdmin",
+        "grantRole",
+        "hasRole",
+        "renounceRole",
+        "revokeRole",
+        "setRoleAdmin",
+    }
+
+
+def test_tip20_role_builder_rejects_invalid_role_length():
+    token = TIP20(ALPHA_USD)
+
+    with pytest.raises(ValueError, match="hash32"):
+        token.grant_role(role="0x1234", account=RECIPIENT)
+
+
+def test_tip20_role_query_helpers_decode_results_and_encode_selectors():
+    token = TIP20(ALPHA_USD)
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.side_effect = [
+        bytes.fromhex("44" * 32),
+        (1).to_bytes(32, "big"),
+        bytes.fromhex("55" * 32),
+        bytes.fromhex("66" * 32),
+        bytes.fromhex("77" * 32),
+        bytes.fromhex("88" * 32),
+    ]
+
+    assert token.get_role_admin(mock_w3, role=ROLE) == bytes.fromhex("44" * 32)
+    assert token.has_role(mock_w3, role=ROLE, account=RECIPIENT) is True
+    assert token.burn_blocked_role(mock_w3) == bytes.fromhex("55" * 32)
+    assert token.issuer_role(mock_w3) == bytes.fromhex("66" * 32)
+    assert token.pause_role(mock_w3) == bytes.fromhex("77" * 32)
+    assert token.unpause_role(mock_w3) == bytes.fromhex("88" * 32)
+
+    expected = [
+        "getRoleAdmin(bytes32)",
+        "hasRole(address,bytes32)",
+        "BURN_BLOCKED_ROLE()",
+        "ISSUER_ROLE()",
+        "PAUSE_ROLE()",
+        "UNPAUSE_ROLE()",
+    ]
+    for call, signature in zip(mock_w3.eth.call.call_args_list, expected, strict=True):
+        tx = call.args[0]
+        assert tx["to"] == ALPHA_USD
+        assert bytes.fromhex(tx["data"][2:10]) == _selector(signature)
+
+
+def test_tip20_has_role_rejects_noncanonical_bool():
+    token = TIP20(ALPHA_USD)
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.return_value = (2).to_bytes(32, "big")
+
+    with pytest.raises(ValueError, match="ABI bool"):
+        token.has_role(mock_w3, role=ROLE, account=RECIPIENT)
+
+
+def test_account_keychain_t5_builders_encode_expected_selectors():
+    restrictions = KeyRestrictions()
+
+    cases = [
+        (
+            AccountKeychain.authorize_admin_key(
+                key_id=RECIPIENT,
+                signature_type=SignatureType.SECP256K1,
+                witness=WITNESS,
+            ),
+            "authorizeAdminKey(address,uint8,bytes32)",
+        ),
+        (
+            AccountKeychain.authorize_key(
+                key_id=RECIPIENT,
+                signature_type=SignatureType.SECP256K1,
+                restrictions=restrictions,
+            ),
+            "authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]))",
+        ),
+        (
+            AccountKeychain.authorize_key(
+                key_id=RECIPIENT,
+                signature_type=SignatureType.SECP256K1,
+                restrictions=restrictions,
+                witness=WITNESS,
+            ),
+            "authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]),bytes32)",
+        ),
+        (
+            AccountKeychain.burn_key_authorization_witness(witness=WITNESS),
+            "burnKeyAuthorizationWitness(bytes32)",
+        ),
+    ]
+
+    for call, signature in cases:
+        assert call.to == bytes.fromhex(ACCOUNT_KEYCHAIN_ADDRESS[2:])
+        assert call.data[:4] == _selector(signature)
+
+
+def test_account_keychain_t5_builders_reject_invalid_witness_length():
+    with pytest.raises(ValueError, match="hash32"):
+        AccountKeychain.authorize_admin_key(
+            key_id=RECIPIENT,
+            signature_type=SignatureType.SECP256K1,
+            witness="0x1234",
+        )
+
+
+def test_account_keychain_authorize_admin_key_rejects_empty_key_id():
+    with pytest.raises(ValueError, match="key_id"):
+        AccountKeychain.authorize_admin_key(
+            key_id="",
+            signature_type=SignatureType.SECP256K1,
+            witness=WITNESS,
+        )
+
+
+def test_account_keychain_legacy_authorize_key_rejects_witness():
+    with pytest.raises(ValueError, match="witnesses"):
+        AccountKeychain.authorize_key(
+            key_id=RECIPIENT,
+            signature_type=SignatureType.SECP256K1,
+            restrictions=KeyRestrictions(),
+            legacy=True,
+            witness=WITNESS,
+        )
+
+
+def test_nonce_get_nonce_rejects_empty_response():
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.return_value = b""
+
+    with pytest.raises(ValueError, match="wrong length"):
+        Nonce.get_nonce(mock_w3, account=RECIPIENT, nonce_key=0)
+
+    tx = mock_w3.eth.call.call_args.args[0]
+    assert tx["to"] == NONCE_ADDRESS
+    assert bytes.fromhex(tx["data"][2:10]) == _selector("getNonce(address,uint256)")

--- a/tests/test_contract_bindings.py
+++ b/tests/test_contract_bindings.py
@@ -118,7 +118,8 @@ def test_tip20_role_query_helpers_decode_results_and_encode_selectors():
         "PAUSE_ROLE()",
         "UNPAUSE_ROLE()",
     ]
-    for call, signature in zip(mock_w3.eth.call.call_args_list, expected, strict=True):
+    assert len(mock_w3.eth.call.call_args_list) == len(expected)
+    for call, signature in zip(mock_w3.eth.call.call_args_list, expected):
         tx = call.args[0]
         assert tx["to"] == ALPHA_USD
         assert bytes.fromhex(tx["data"][2:10]) == _selector(signature)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -84,6 +84,19 @@ class TestGetRemainingLimit:
 
         assert result == 0
 
+    def test_rejects_empty_response(self):
+        """Should reject malformed RPC responses."""
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = b""
+
+        with pytest.raises(ValueError, match="wrong length"):
+            AccountKeychain.get_remaining_limit(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+                token_address="0x" + "c" * 40,
+            )
+
     def test_raises_on_empty_account(self):
         """Should raise ValueError if account_address is empty."""
         mock_w3 = MagicMock()
@@ -118,6 +131,133 @@ class TestGetRemainingLimit:
                 account_address="0x" + "a" * 40,
                 key_id="0x" + "b" * 40,
                 token_address="",
+            )
+
+
+class TestT5AccountKeychainQueries:
+    """Tests for T5 AccountKeychain query helpers."""
+
+    def test_get_remaining_limit_with_period_parses_values(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (1000).to_bytes(32, "big") + (
+            1893456000
+        ).to_bytes(32, "big")
+
+        result = AccountKeychain.get_remaining_limit_with_period(
+            mock_w3,
+            account_address="0x" + "a" * 40,
+            key_id="0x" + "b" * 40,
+            token_address="0x" + "c" * 40,
+        )
+
+        assert result == {"remaining": 1000, "period_end": 1893456000}
+
+    def test_get_remaining_limit_with_period_rejects_wrong_length(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = b"\x00" * 32
+
+        with pytest.raises(ValueError, match="wrong length"):
+            AccountKeychain.get_remaining_limit_with_period(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+                token_address="0x" + "c" * 40,
+            )
+
+    def test_get_remaining_limit_with_period_rejects_period_overflow(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (1000).to_bytes(32, "big") + (2**64).to_bytes(
+            32, "big"
+        )
+
+        with pytest.raises(ValueError, match="uint64"):
+            AccountKeychain.get_remaining_limit_with_period(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+                token_address="0x" + "c" * 40,
+            )
+
+    def test_get_transaction_key_parses_address(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = b"\x00" * 12 + bytes.fromhex("d" * 40)
+
+        result = AccountKeychain.get_transaction_key(mock_w3)
+
+        assert result.lower() == ("0x" + "d" * 40).lower()
+
+    def test_get_transaction_key_rejects_wrong_length(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = b"\x00" * 31
+
+        with pytest.raises(ValueError, match="wrong length"):
+            AccountKeychain.get_transaction_key(mock_w3)
+
+    def test_is_admin_key_parses_bool(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (1).to_bytes(32, "big")
+
+        result = AccountKeychain.is_admin_key(
+            mock_w3,
+            account_address="0x" + "a" * 40,
+            key_id="0x" + "b" * 40,
+        )
+
+        assert result is True
+
+    def test_is_admin_key_rejects_wrong_length(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = b"\x00" * 31
+
+        with pytest.raises(ValueError, match="wrong length"):
+            AccountKeychain.is_admin_key(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+            )
+
+    def test_is_admin_key_rejects_noncanonical_bool(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (2).to_bytes(32, "big")
+
+        with pytest.raises(ValueError, match="ABI bool"):
+            AccountKeychain.is_admin_key(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+            )
+
+    def test_is_key_authorization_witness_burned_parses_bool(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (0).to_bytes(32, "big")
+
+        result = AccountKeychain.is_key_authorization_witness_burned(
+            mock_w3,
+            account_address="0x" + "a" * 40,
+            witness="0x" + "1" * 64,
+        )
+
+        assert result is False
+
+    def test_is_key_authorization_witness_burned_rejects_invalid_witness(self):
+        mock_w3 = MagicMock()
+
+        with pytest.raises(ValueError, match="hash32"):
+            AccountKeychain.is_key_authorization_witness_burned(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                witness="0x1234",
+            )
+
+    def test_is_key_authorization_witness_burned_rejects_noncanonical_bool(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (2).to_bytes(32, "big")
+
+        with pytest.raises(ValueError, match="ABI bool"):
+            AccountKeychain.is_key_authorization_witness_burned(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                witness="0x" + "1" * 64,
             )
 
 
@@ -183,6 +323,18 @@ class TestGetKey:
         )
 
         assert info["is_revoked"] is True
+
+    def test_rejects_noncanonical_bool(self):
+        """Should reject malformed ABI bool words."""
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = self._build_result(enforce_limits=2)
+
+        with pytest.raises(ValueError, match="ABI bool"):
+            AccountKeychain.get_key(
+                mock_w3,
+                account_address="0x" + "a" * 40,
+                key_id="0x" + "b" * 40,
+            )
 
     def test_parses_enforce_limits(self):
         """Should detect enforce_limits=true."""


### PR DESCRIPTION
## Summary

Adds T5 hardfork support to the contract bindings.

- Refreshes vendored Tempo ABIs for T5, including `IAccountKeychain`, `ITIP20`, `IStablecoinDEX`, `IFeeManager`, `INonce`, and new `ITIP20RolesAuth`.
- Adds typed helpers for T5 Account Keychain features: key authorization witnesses, admin key authorization, burned witness checks, transaction key lookup,
admin-key checks, and period-aware spending limits.
- Extends TIP-20 bindings with T5 token admin, reward, policy, pause/unpause, blocked-burn, and role-management calls.
- Adds shared strict ABI return decoders for uints, uint64, bools, addresses, and bytes32 values.
- Updates ABI sync tooling and expands tests for new T5 call builders, query decoding, selector coverage, and malformed RPC responses.

Closes OSS-300

## Testing

- Added unit coverage for T5 contract builders and keychain query helpers.