### PR TITLE
fix(ci): use current testnet hardfork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,4 +214,3 @@ jobs:
         run: uv run pytest -v -s tests/test_integration.py
         env:
           TEMPO_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
-          TEMPO_HARDFORK: T2


### PR DESCRIPTION
## Summary
- Remove the stale `TEMPO_HARDFORK=T2` override from the testnet integration job so it uses the default T3+ keychain encoding.

## Verification
- `TEMPO_RPC_URL=https://rpc.testnet.tempo.xyz uv run pytest -v -s tests/test_integration.py::TestKeychainSelectors::test_authorize_get_revoke_round_trip`
- `uv run pytest -q tests/ --ignore=tests/test_integration.py`

Prompted by: @grandizzy