### PR TITLE
feat: add keychain verify

### DIFF
--- a/.changelog/t6-keychain-verify.md
+++ b/.changelog/t6-keychain-verify.md
@@ -1,0 +1,9 @@
+---
+pytempo: minor
+---
+
+Expose the T6 (TIP-1049) stateful keychain signature checks on the
+`SignatureVerifier` precompile binding: `verify_keychain(account, hash, signature)`
+and `verify_keychain_admin(account, hash, signature)`. Bumped the vendored
+`tempo-std` ABI ref to pick up the `verifyKeychain` / `verifyKeychainAdmin`
+additions to `ISignatureVerifier`.

--- a/pytempo/contracts/abis/ISignatureVerifier.json
+++ b/pytempo/contracts/abis/ISignatureVerifier.json
@@ -61,5 +61,63 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "verifyKeychain",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "verifyKeychainAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/pytempo/contracts/signature_verifier.py
+++ b/pytempo/contracts/signature_verifier.py
@@ -10,11 +10,25 @@ SignatureVerifier precompile at :data:`SIGNATURE_VERIFIER_ADDRESS`.
     signer = SignatureVerifier.recover(w3, hash=digest, signature=sig)
     ok = SignatureVerifier.verify(w3, signer=addr, hash=digest, signature=sig)
 
-.. note::
-    T6 (TIP-1049) adds stateful keychain helpers ``verifyKeychain`` and
-    ``verifyKeychainAdmin`` to this precompile. They are not yet exposed in the
-    ``tempo-std`` ``ISignatureVerifier`` interface, so they are intentionally
-    omitted here until the interface ships them (keeping vendored ABIs in sync).
+T6 (TIP-1049) adds stateful keychain helpers that validate a signature against an
+account's live ``AccountKeychain`` state::
+
+    ok = SignatureVerifier.verify_keychain(w3, account=acct, hash=digest, signature=sig)
+    ok = SignatureVerifier.verify_keychain_admin(w3, account=acct, hash=digest, signature=sig)
+
+Both require a **V2 keychain signature envelope** (``0x04 || account || inner``),
+not a raw 65-byte signature, and the embedded address must equal ``account``.
+They differ in which keys count as valid:
+
+- :meth:`verify_keychain` — an active access key (admin or non-admin). The root
+  key alone is **not** accepted.
+- :meth:`verify_keychain_admin` — the account's root key **or** an active admin
+  access key. Non-admin access keys are rejected.
+
+When asking a user or key to sign a digest for :meth:`verify_keychain_admin`,
+domain-separate it with replay context (chain id, verifying contract, account,
+the specific action/purpose, and a nonce and/or deadline) so an admin proof
+cannot be replayed for a different action.
 """
 
 from __future__ import annotations
@@ -61,3 +75,57 @@ class SignatureVerifier:
         )
         result = w3.eth.call({"to": SIGNATURE_VERIFIER_ADDRESS, "data": call_data})
         return decode_bool(result, "verify")
+
+    @staticmethod
+    def verify_keychain(
+        w3,
+        *,
+        account: str,
+        hash: BytesLike,
+        signature: BytesLike,
+    ) -> bool:
+        """Return whether ``signature`` over ``hash`` is from an active access key of ``account``.
+
+        T6 (TIP-1049) stateful check: requires a V2 keychain envelope whose
+        embedded address equals ``account``, and returns ``True`` only if the
+        recovered key is an active access key (admin or non-admin) for
+        ``account``. The root key alone does **not** satisfy this check; use
+        :meth:`verify_keychain_admin` for root/admin semantics.
+        """
+        if not account:
+            raise ValueError("account required")
+        call_data = encode_calldata(
+            _ABI, "verifyKeychain", [account, as_hash32(hash), as_bytes(signature)]
+        )
+        result = w3.eth.call({"to": SIGNATURE_VERIFIER_ADDRESS, "data": call_data})
+        return decode_bool(result, "verifyKeychain")
+
+    @staticmethod
+    def verify_keychain_admin(
+        w3,
+        *,
+        account: str,
+        hash: BytesLike,
+        signature: BytesLike,
+    ) -> bool:
+        """Return whether ``signature`` over ``hash`` is from the root or an admin key of ``account``.
+
+        T6 (TIP-1049) stateful check with "root key or admin key of this account
+        signed this" semantics: requires a V2 keychain envelope whose embedded
+        address equals ``account``, and returns ``True`` for the account's root
+        key or an active admin access key (non-admin access keys are rejected).
+
+        The ``account`` is **not** bound into ``hash``; callers should
+        domain-separate the signed digest with replay context (chain id,
+        verifying contract, account, action/purpose, and a nonce and/or
+        deadline) to prevent admin-proof replay.
+        """
+        if not account:
+            raise ValueError("account required")
+        call_data = encode_calldata(
+            _ABI,
+            "verifyKeychainAdmin",
+            [account, as_hash32(hash), as_bytes(signature)],
+        )
+        result = w3.eth.call({"to": SIGNATURE_VERIFIER_ADDRESS, "data": call_data})
+        return decode_bool(result, "verifyKeychainAdmin")

--- a/scripts/tempo_abis.sh
+++ b/scripts/tempo_abis.sh
@@ -22,7 +22,7 @@ REPO="tempoxyz/tempo-std"
 # reproducible and ABIs can't silently drift with tempo-std's default branch.
 # Bump this (and re-run --sync) to adopt newer interfaces. Override per-run with
 # TEMPO_STD_REF=<sha|tag|branch>.
-REF="${TEMPO_STD_REF:-b0cc603b14bed2e26e584cb2ff2f19227f2e25d4}"
+REF="${TEMPO_STD_REF:-84baf1077e1d704d4197845d48cf2b9e7148a6df}"
 INTERFACES=(ITIP20 ITIP20RolesAuth IAccountKeychain IStablecoinDEX IFeeManager IFeeAMM INonce ITIP403Registry IReceivePolicyGuard ISignatureVerifier)
 ABI_DIR="$(cd "$(dirname "$0")/.." && pwd)/pytempo/contracts/abis"
 

--- a/tests/test_t6_bindings.py
+++ b/tests/test_t6_bindings.py
@@ -141,6 +141,42 @@ class TestSignatureVerifier:
                 MagicMock(), signer="", hash="0x" + "11" * 32, signature=b"\x00" * 65
             )
 
+    def test_verify_keychain(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (1).to_bytes(32, "big")
+        ok = SignatureVerifier.verify_keychain(
+            mock_w3, account=ADDR, hash="0x" + "11" * 32, signature=b"\x00" * 65
+        )
+        assert ok is True
+        sent = mock_w3.eth.call.call_args[0][0]
+        assert bytes.fromhex(sent["data"][2:10]) == _selector(
+            "verifyKeychain(address,bytes32,bytes)"
+        )
+
+    def test_verify_keychain_admin(self):
+        mock_w3 = MagicMock()
+        mock_w3.eth.call.return_value = (0).to_bytes(32, "big")
+        ok = SignatureVerifier.verify_keychain_admin(
+            mock_w3, account=ADDR, hash="0x" + "11" * 32, signature=b"\x00" * 65
+        )
+        assert ok is False
+        sent = mock_w3.eth.call.call_args[0][0]
+        assert bytes.fromhex(sent["data"][2:10]) == _selector(
+            "verifyKeychainAdmin(address,bytes32,bytes)"
+        )
+
+    def test_verify_keychain_requires_account(self):
+        with pytest.raises(ValueError, match="account"):
+            SignatureVerifier.verify_keychain(
+                MagicMock(), account="", hash="0x" + "11" * 32, signature=b"\x00" * 65
+            )
+
+    def test_verify_keychain_admin_requires_account(self):
+        with pytest.raises(ValueError, match="account"):
+            SignatureVerifier.verify_keychain_admin(
+                MagicMock(), account="", hash="0x" + "11" * 32, signature=b"\x00" * 65
+            )
+
 
 def test_addresses():
     assert TIP403_REGISTRY_ADDRESS.lower().startswith("0x403c")


### PR DESCRIPTION
Adds the T6/TIP-1049 `SignatureVerifier.verify_keychain` and `verify_keychain_admin` methods. Last remaining T6 gap. ABI synced from tempo-std #122.

Closes OSS-390