### PR TITLE
feat: add DEX storageCredits

### DIFF
--- a/.changelog/t7-dex-storage-credits.md
+++ b/.changelog/t7-dex-storage-credits.md
@@ -1,0 +1,6 @@
+---
+pytempo: minor
+---
+
+Add the `StablecoinDEX.storage_credits(w3, user=...)` view (TIP-1064) to query a
+maker's reusable order-storage credit balance on the Stablecoin DEX.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ EIP-2930 access list entry.
 Typed call builders for Tempo precompiles and tokens:
 
 - `TIP20` — TIP-20 token operations (transfer, approve, mint, burn, permit)
-- `StablecoinDEX` — Stablecoin DEX operations (place, cancel, swap, withdraw)
+- `StablecoinDEX` — Stablecoin DEX operations (place, cancel, swap, withdraw, storage_credits query)
 - `AccountKeychain` — Access key management (authorize, revoke, spending limits, queries)
 - `FeeAMM` — Fee AMM liquidity operations (mint, burn, rebalance_swap)
 - `FeeManager` — Fee manager operations (set fee token, distribute fees); inherits `FeeAMM`

--- a/pytempo/contracts/dex.py
+++ b/pytempo/contracts/dex.py
@@ -11,6 +11,7 @@ Returns :class:`~pytempo.Call` objects ready to use in a
 
 from pytempo.models import Call
 
+from ._decode import decode_u64
 from ._encode import encode_calldata
 from .abis import STABLECOIN_DEX_ABI
 from .addresses import STABLECOIN_DEX_ADDRESS
@@ -102,3 +103,28 @@ class StablecoinDEX:
         """Build a ``createPair(address)`` call."""
         data = encode_calldata(_ABI, "createPair", [base])
         return Call.create(to=STABLECOIN_DEX_ADDRESS, data=data)
+
+    @staticmethod
+    def storage_credits(w3, *, user: str) -> int:
+        """Query the reusable order-storage credits owned by ``user`` (TIP-1064).
+
+        A maker earns one credit for each of their own order-record storage
+        slots that is freed, and can apply it to offset the cost of creating
+        storage for a later order.
+
+        Args:
+            w3: Web3 instance connected to a Tempo RPC.
+            user: The user whose DEX storage-credit balance is queried.
+
+        Returns:
+            The number of storage credits available to ``user`` (saturates at
+            ``uint64`` max).
+
+        Raises:
+            ValueError: If ``user`` is empty or the result is malformed.
+        """
+        if not user:
+            raise ValueError("user required")
+        call_data = encode_calldata(_ABI, "storageCredits", [user])
+        result = w3.eth.call({"to": STABLECOIN_DEX_ADDRESS, "data": call_data})
+        return decode_u64(result, "storageCredits")

--- a/tests/test_contract_bindings.py
+++ b/tests/test_contract_bindings.py
@@ -6,9 +6,20 @@ import pytest
 from eth_utils import function_signature_to_4byte_selector
 
 from pytempo import KeyRestrictions
-from pytempo.contracts import ALPHA_USD, BETA_USD, TIP20, TIP20_ROLES_AUTH_ABI, Nonce
+from pytempo.contracts import (
+    ALPHA_USD,
+    BETA_USD,
+    TIP20,
+    TIP20_ROLES_AUTH_ABI,
+    Nonce,
+    StablecoinDEX,
+)
 from pytempo.contracts.account_keychain import AccountKeychain
-from pytempo.contracts.addresses import ACCOUNT_KEYCHAIN_ADDRESS, NONCE_ADDRESS
+from pytempo.contracts.addresses import (
+    ACCOUNT_KEYCHAIN_ADDRESS,
+    NONCE_ADDRESS,
+    STABLECOIN_DEX_ADDRESS,
+)
 from pytempo.keychain import SignatureType
 
 RECIPIENT = "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55"
@@ -213,3 +224,29 @@ def test_nonce_get_nonce_rejects_empty_response():
     tx = mock_w3.eth.call.call_args.args[0]
     assert tx["to"] == NONCE_ADDRESS
     assert bytes.fromhex(tx["data"][2:10]) == _selector("getNonce(address,uint256)")
+
+
+def test_dex_storage_credits_decodes_and_encodes_selector():
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.return_value = (7).to_bytes(32, "big")
+
+    assert StablecoinDEX.storage_credits(mock_w3, user=RECIPIENT) == 7
+
+    tx = mock_w3.eth.call.call_args.args[0]
+    assert tx["to"] == STABLECOIN_DEX_ADDRESS
+    assert bytes.fromhex(tx["data"][2:10]) == _selector("storageCredits(address)")
+    # the user address is encoded (left-padded to 32 bytes) into the calldata
+    assert tx["data"][10:].lower() == ("0" * 24) + RECIPIENT[2:].lower()
+
+
+def test_dex_storage_credits_rejects_empty_user():
+    with pytest.raises(ValueError, match="user required"):
+        StablecoinDEX.storage_credits(MagicMock(), user="")
+
+
+def test_dex_storage_credits_rejects_overflow():
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.return_value = (2**64).to_bytes(32, "big")
+
+    with pytest.raises(ValueError, match="uint64"):
+        StablecoinDEX.storage_credits(mock_w3, user=RECIPIENT)


### PR DESCRIPTION
Add `StablecoinDEX.storage_credits(w3, user=...)` view (TIP-1064) to query a maker's reusable order-storage credit balance on the Stablecoin DEX.