### PR TITLE
docs: deprecate TIP20 rewards

### DIFF
--- a/.changelog/t7-rewards-deprecation.md
+++ b/.changelog/t7-rewards-deprecation.md
@@ -1,0 +1,8 @@
+---
+pytempo: patch
+---
+
+Document T7 changes: mark the TIP-20 reward builders `distribute_reward` and
+`set_reward_recipient` as deprecated (TIP-1075 — post-T7 no-ops; `claim_rewards`
+still pays already-settled balances), and note the dynamic base fee (TIP-1067)
+so `max_fee_per_gas` should come from a live estimate rather than a constant.

--- a/.changelog/t7-rewards-deprecation.md
+++ b/.changelog/t7-rewards-deprecation.md
@@ -3,6 +3,8 @@ pytempo: patch
 ---
 
 Document T7 changes: mark the TIP-20 reward builders `distribute_reward` and
-`set_reward_recipient` as deprecated (TIP-1075 — post-T7 no-ops; `claim_rewards`
-still pays already-settled balances), and note the dynamic base fee (TIP-1067)
-so `max_fee_per_gas` should come from a live estimate rather than a constant.
+`set_reward_recipient` as deprecated (TIP-1075 — post-T7 no-ops). `claim_rewards`
+stays valid: it still checkpoints and settles pre-T7 lazy accruals through T7,
+and pays only already-settled balances from the T8 cleanup fork. Also note the
+dynamic base fee (TIP-1067) so `max_fee_per_gas` should come from a live estimate
+rather than a constant.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,13 @@ Immutable, strongly-typed transaction (frozen attrs model).
 - `calls` (tuple[Call, ...]) - Tuple of Call objects
 - `access_list` (tuple[AccessListItem, ...]) - EIP-2930 access list
 
+> **Note (T7 / TIP-1067):** the base fee is now dynamic — it floats within a
+> protocol-bounded range instead of being fixed, rising under load and decaying
+> when idle. The range is capped below the old fixed base fee, so fees never
+> exceed pre-T7 pricing. Still set `max_fee_per_gas` from a live fee estimate
+> rather than a hardcoded constant; the `2_000_000_000` values in the examples
+> above are illustrative only.
+
 **Methods:**
 
 - `sign(private_key, for_fee_payer=False)` - Sign transaction (returns new instance)

--- a/pytempo/contracts/tip20.py
+++ b/pytempo/contracts/tip20.py
@@ -111,7 +111,13 @@ class TIP20:
         return Call.create(to=self.token, data=data)
 
     def claim_rewards(self) -> Call:
-        """Build a ``claimRewards()`` call."""
+        """Build a ``claimRewards()`` call.
+
+        Note:
+            TIP-20 rewards are deprecated as of the T7 upgrade (TIP-1075).
+            ``claimRewards`` remains valid but, post-T7, only pays out
+            already-settled reward balances; no new rewards accrue.
+        """
         data = encode_calldata(_ABI, "claimRewards", [])
         return Call.create(to=self.token, data=data)
 
@@ -121,7 +127,12 @@ class TIP20:
         return Call.create(to=self.token, data=data)
 
     def distribute_reward(self, *, amount: int) -> Call:
-        """Build a ``distributeReward(uint256)`` call."""
+        """Build a ``distributeReward(uint256)`` call.
+
+        .. deprecated:: T7
+            TIP-20 rewards are deprecated (TIP-1075). Post-T7 this call is a
+            non-reverting no-op: no new rewards are distributed.
+        """
         data = encode_calldata(_ABI, "distributeReward", [amount])
         return Call.create(to=self.token, data=data)
 
@@ -141,7 +152,12 @@ class TIP20:
         return Call.create(to=self.token, data=data)
 
     def set_reward_recipient(self, *, new_reward_recipient: str) -> Call:
-        """Build a ``setRewardRecipient(address)`` call."""
+        """Build a ``setRewardRecipient(address)`` call.
+
+        .. deprecated:: T7
+            TIP-20 rewards are deprecated (TIP-1075). Post-T7 this call is a
+            non-reverting no-op: reward opt-ins/recipients no longer change.
+        """
         data = encode_calldata(_ABI, "setRewardRecipient", [new_reward_recipient])
         return Call.create(to=self.token, data=data)
 

--- a/pytempo/contracts/tip20.py
+++ b/pytempo/contracts/tip20.py
@@ -114,9 +114,10 @@ class TIP20:
         """Build a ``claimRewards()`` call.
 
         Note:
-            TIP-20 rewards are deprecated as of the T7 upgrade (TIP-1075).
-            ``claimRewards`` remains valid but, post-T7, only pays out
-            already-settled reward balances; no new rewards accrue.
+            TIP-20 rewards are deprecated by the T7 upgrade (TIP-1075): no new
+            rewards accrue post-T7. ``claimRewards`` stays valid — through T7 it
+            still checkpoints and settles pre-T7 lazy accruals, and from the T8
+            cleanup fork it pays out only already-settled reward balances.
         """
         data = encode_calldata(_ABI, "claimRewards", [])
         return Call.create(to=self.token, data=data)


### PR DESCRIPTION
Document T7 behavior (docs-only, no API change): deprecate the TIP-20 reward builders (`distribute_reward` and `set_reward_recipient` are post-T7 no-ops per TIP-1075; `claim_rewards` still pays already-settled balances) and note the dynamic base fee (TIP-1067) so `max_fee_per_gas` should come from a live estimate rather than a hardcoded constant.