### PR TITLE
fix: sync package version in __init__.py with pyproject.toml

### DIFF
--- a/pytempo/__init__.py
+++ b/pytempo/__init__.py
@@ -55,7 +55,7 @@ from .types import (
     validate_nonempty_address,
 )
 
-__version__ = "0.3.1"
+__version__ = "0.5.1"
 
 __all__ = [
     # Types


### PR DESCRIPTION
## Description
Package version is desynchronized between files:
- `pyproject.toml`: 0.5.1
- `pytempo/__init__.py`: 0.3.1 (was outdated)

Update `__version__` in `pytempo/__init__.py` to match `pyproject.toml`