### PR TITLE
Expose Tempo transaction signing preimage

### DIFF
--- a/.changelog/signing-preimage.md
+++ b/.changelog/signing-preimage.md
@@ -1,0 +1,6 @@
+---
+pytempo: minor
+---
+
+Expose the exact Tempo transaction signing preimage with
+`TempoTransaction.encode_for_signing()`.

--- a/.changelog/signing-preimage.md
+++ b/.changelog/signing-preimage.md
@@ -1,6 +1,0 @@
----
-pytempo: minor
----
-
-Expose the exact Tempo transaction signing preimage with
-`TempoTransaction.encode_for_signing()`.

--- a/.changelog/tall-ducks-write.md
+++ b/.changelog/tall-ducks-write.md
@@ -1,0 +1,5 @@
+---
+pytempo: minor
+---
+
+Exposed the Tempo transaction signing preimage via `TempoTransaction.encode_for_signing()`, allowing callers to access the exact byte sequence that is hashed for signing. Refactored internal `_signing_hash_*` methods into `_encode_for_*_signing()` helpers and added tests verifying the preimage matches the signing hash.

--- a/pytempo/models.py
+++ b/pytempo/models.py
@@ -394,11 +394,20 @@ class TempoTransaction:
         Returns:
             32-byte hash to sign
         """
-        if for_fee_payer:
-            return self._signing_hash_fee_payer()
-        return self._signing_hash_sender()
+        return keccak(self.encode_for_signing(for_fee_payer=for_fee_payer))
 
-    def _signing_hash_sender(self) -> bytes:
+    def encode_for_signing(self, for_fee_payer: bool = False) -> bytes:
+        """Encode the transaction preimage used for signing.
+
+        This is the exact byte sequence hashed by :meth:`get_signing_hash`.
+        It is useful for protocols that bind transaction context before the
+        transaction is broadcast.
+        """
+        if for_fee_payer:
+            return self._encode_for_fee_payer_signing()
+        return self._encode_for_sender_signing()
+
+    def _encode_for_sender_signing(self) -> bytes:
         self.validate()
         has_fee_payer = self._has_fee_payer()
 
@@ -423,9 +432,9 @@ class TempoTransaction:
         if self.key_authorization is not None:
             fields.append(self.key_authorization.as_rlp_payload())
 
-        return keccak(bytes([self.TRANSACTION_TYPE]) + rlp.encode(fields))
+        return bytes([self.TRANSACTION_TYPE]) + rlp.encode(fields)
 
-    def _signing_hash_fee_payer(self) -> bytes:
+    def _encode_for_fee_payer_signing(self) -> bytes:
         self.validate(require_sender=True)
 
         fields = [
@@ -447,7 +456,7 @@ class TempoTransaction:
         if self.key_authorization is not None:
             fields.append(self.key_authorization.as_rlp_payload())
 
-        return keccak(bytes([self.FEE_PAYER_MAGIC_BYTE]) + rlp.encode(fields))
+        return bytes([self.FEE_PAYER_MAGIC_BYTE]) + rlp.encode(fields)
 
     def encode(self) -> bytes:
         """Encode complete transaction: ``0x76 || rlp([fields])``."""

--- a/tests/test_typed_models.py
+++ b/tests/test_typed_models.py
@@ -1,6 +1,7 @@
 """Tests for the strongly-typed models."""
 
 import pytest
+from eth_utils import keccak
 
 from pytempo import (
     AccessListItem,
@@ -192,6 +193,50 @@ class TestTempoTransaction:
         assert signed_tx.sender_signature is not None
         assert signed_tx.sender_address is not None
         assert tx.sender_signature is None
+
+    @pytest.mark.parametrize(
+        ("awaiting_fee_payer", "expected"),
+        [
+            (
+                False,
+                "76f86682a5bf0102830f4240dcdb944d50500000000000000000000000000000000000"
+                "808412345678c0a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                "ffffffff0784713fb3008094000000000000000000000000000000000000000380c0",
+            ),
+            (
+                True,
+                "76f85282a5bf0102830f4240dcdb944d50500000000000000000000000000000000000"
+                "808412345678c0a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                "ffffffff0784713fb300808000c0",
+            ),
+        ],
+    )
+    def test_encode_for_signing_matches_signing_hash(
+        self, awaiting_fee_payer, expected
+    ):
+        tx = TempoTransaction.create(
+            chain_id=42431,
+            gas_limit=1_000_000,
+            max_fee_per_gas=2,
+            max_priority_fee_per_gas=1,
+            nonce=7,
+            nonce_key=(1 << 256) - 1,
+            valid_before=1_900_000_000,
+            fee_token="0x0000000000000000000000000000000000000003",
+            awaiting_fee_payer=awaiting_fee_payer,
+            calls=(
+                Call.create(
+                    to="0x4d50500000000000000000000000000000000000",
+                    data="0x12345678",
+                ),
+            ),
+        )
+
+        encoded = tx.encode_for_signing()
+
+        assert encoded[0] == tx.TRANSACTION_TYPE
+        assert keccak(encoded) == tx.get_signing_hash()
+        assert encoded.hex() == expected
 
     def test_create_factory(self):
         tx = TempoTransaction.create(


### PR DESCRIPTION
## Summary
- expose `TempoTransaction.encode_for_signing()`
- derive existing signing hashes from that exact preimage
- pin unsponsored and sponsored encoding against Ox golden vectors

This is the generic transaction seam needed to derive TIP-1034 channel identity without duplicating Tempo RLP internals in pympp.

## Validation
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` (242 passed, 36 skipped)
