### PR TITLE
docs: examples connect to testnet, not devnet

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,6 @@ PRIVATE_KEY=0xYourPrivateKeyHere python examples/batch_calls.py
 
 ## Notes
 
-- All examples connect to Tempo devnet
+- All examples connect to Tempo testnet
 - Tempo doesn't support native transfers (sending ETH value), so transactions use value=0
 - Gas is paid in custom fee tokens (ERC-20)


### PR DESCRIPTION
The examples README states all examples connect to devnet, but both `simple_send.py` and `batch_calls.py` connect to `https://rpc.testnet.tempo.xyz` (testnet). This corrects the note so it matches the code.