### PR TITLE
feat(tip20): add scalar view helpers

### DIFF
--- a/.changelog/tip20-scalar-read-helpers.md
+++ b/.changelog/tip20-scalar-read-helpers.md
@@ -1,0 +1,7 @@
+---
+pytempo: minor
+---
+
+Add scalar view helpers to `TIP20`: `balance_of`, `allowance`, `total_supply`,
+`decimals`, `supply_cap`, and `paused`. These mirror the existing role query
+helpers, returning decoded Python values from a single `eth_call`.

--- a/pytempo/contracts/tip20.py
+++ b/pytempo/contracts/tip20.py
@@ -13,7 +13,7 @@ Returns :class:`~pytempo.Call` objects ready to use in a
 from pytempo.models import Call
 from pytempo.types import BytesLike, as_hash32
 
-from ._decode import decode_bool, decode_hash32
+from ._decode import decode_bool, decode_hash32, decode_uint
 from ._encode import encode_calldata
 from .abis import TIP20_ABI, TIP20_ROLES_AUTH_ABI
 
@@ -192,6 +192,45 @@ class TIP20:
             _ABI, "permit", [owner, spender, value, deadline, v, r, s]
         )
         return Call.create(to=self.token, data=data)
+
+    def balance_of(self, w3, *, account: str) -> int:
+        """Query ``balanceOf(address)``."""
+        _require_account(account)
+        call_data = encode_calldata(_ABI, "balanceOf", [account])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_uint(result, "balanceOf")
+
+    def allowance(self, w3, *, owner: str, spender: str) -> int:
+        """Query ``allowance(address,address)``."""
+        _require_account(owner)
+        _require_account(spender)
+        call_data = encode_calldata(_ABI, "allowance", [owner, spender])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_uint(result, "allowance")
+
+    def total_supply(self, w3) -> int:
+        """Query ``totalSupply()``."""
+        call_data = encode_calldata(_ABI, "totalSupply", [])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_uint(result, "totalSupply")
+
+    def decimals(self, w3) -> int:
+        """Query ``decimals()``."""
+        call_data = encode_calldata(_ABI, "decimals", [])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_uint(result, "decimals")
+
+    def supply_cap(self, w3) -> int:
+        """Query ``supplyCap()``."""
+        call_data = encode_calldata(_ABI, "supplyCap", [])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_uint(result, "supplyCap")
+
+    def paused(self, w3) -> bool:
+        """Query ``paused()``."""
+        call_data = encode_calldata(_ABI, "paused", [])
+        result = w3.eth.call({"to": self.token, "data": call_data})
+        return decode_bool(result, "paused")
 
     def grant_role(self, *, role: BytesLike, account: str) -> Call:
         """Build a ``grantRole(bytes32,address)`` call."""

--- a/tests/test_contract_bindings.py
+++ b/tests/test_contract_bindings.py
@@ -145,6 +145,54 @@ def test_tip20_has_role_rejects_noncanonical_bool():
         token.has_role(mock_w3, role=ROLE, account=RECIPIENT)
 
 
+def test_tip20_scalar_read_helpers_decode_and_encode_selectors():
+    token = TIP20(ALPHA_USD)
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.side_effect = [
+        (1000).to_bytes(32, "big"),
+        (500).to_bytes(32, "big"),
+        (10_000).to_bytes(32, "big"),
+        (6).to_bytes(32, "big"),
+        (2**80).to_bytes(32, "big"),
+        (1).to_bytes(32, "big"),
+    ]
+
+    assert token.balance_of(mock_w3, account=RECIPIENT) == 1000
+    assert token.allowance(mock_w3, owner=RECIPIENT, spender=BETA_USD) == 500
+    assert token.total_supply(mock_w3) == 10_000
+    assert token.decimals(mock_w3) == 6
+    assert token.supply_cap(mock_w3) == 2**80
+    assert token.paused(mock_w3) is True
+
+    expected = [
+        "balanceOf(address)",
+        "allowance(address,address)",
+        "totalSupply()",
+        "decimals()",
+        "supplyCap()",
+        "paused()",
+    ]
+    assert len(mock_w3.eth.call.call_args_list) == len(expected)
+    for call, signature in zip(mock_w3.eth.call.call_args_list, expected):
+        tx = call.args[0]
+        assert tx["to"] == ALPHA_USD
+        assert bytes.fromhex(tx["data"][2:10]) == _selector(signature)
+
+
+def test_tip20_balance_of_rejects_empty_account():
+    with pytest.raises(ValueError, match="account required"):
+        TIP20(ALPHA_USD).balance_of(MagicMock(), account="")
+
+
+def test_tip20_paused_rejects_noncanonical_bool():
+    token = TIP20(ALPHA_USD)
+    mock_w3 = MagicMock()
+    mock_w3.eth.call.return_value = (2).to_bytes(32, "big")
+
+    with pytest.raises(ValueError, match="ABI bool"):
+        token.paused(mock_w3)
+
+
 def test_account_keychain_t5_builders_encode_expected_selectors():
     restrictions = KeyRestrictions()
 


### PR DESCRIPTION
## Summary

`TIP20` already exposes typed **role** query helpers (`has_role`, `get_role_admin`, the role constants) and typed **write** builders for the full token interface, but it has no helpers for the standard scalar **reads** — callers have to drop down to `w3.eth.contract(TIP20_ABI)` just to read a balance.

This adds six scalar view helpers to `TIP20`, following the existing role-query pattern (encode calldata from the shipped ABI → `eth_call` → decode a single word):

- `balance_of(w3, *, account)` → `balanceOf(address)`
- `allowance(w3, *, owner, spender)` → `allowance(address,address)`
- `total_supply(w3)` → `totalSupply()`
- `decimals(w3)` → `decimals()`
- `supply_cap(w3)` → `supplyCap()` (complements the existing `set_supply_cap`)
- `paused(w3)` → `paused()` (complements the existing `pause` / `unpause`)

All decode via the existing `_decode` helpers (`decode_uint` / `decode_bool`); no new decoding machinery is introduced. String views (`name` / `symbol`) are intentionally left out as they require dynamic ABI decoding.

## Tests

Unit tests cover selector encoding, result decoding, empty-address rejection, and non-canonical bool rejection.

## Changelog

Includes a `pytempo: minor` changelog fragment.