### PR TITLE
fix: support Core Metadata 2.5 releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: true
 
-      - uses: wevm/changelogs@3f5a172c4c58de20cc77b40f735ea20e8c07028a # OIDC trusted publishing
+      - uses: tempoxyz/changelogs@ec992966ce14836e96ef5bd6258683963130cd2e # OIDC trusted publishing
         with:
           ecosystem: python
           python-version: '3.12'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: true
 
-      - uses: tempoxyz/changelogs@ec992966ce14836e96ef5bd6258683963130cd2e # OIDC trusted publishing
+      - uses: tempoxyz/changelogs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d # OIDC trusted publishing
         with:
           ecosystem: python
           python-version: '3.12'


### PR DESCRIPTION
## Why

Current Hatchling builds emit Core Metadata 2.5, which the pinned Twine 6.2 release action rejects. The pending `v0.6.0` release would hit the same publisher failure.

## What

- Pin the canonical `tempoxyz/changelogs` action to the tested Twine 7 fix from [tempoxyz/changelogs#148](https://github.com/tempoxyz/changelogs/pull/148).
- Leave package code and release contents unchanged.