### PR TITLE
fix: preserve release changelog attribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: true
 
       - uses: tempoxyz/changelogs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d # OIDC trusted publishing


### PR DESCRIPTION
## Why

The release workflow checks out only one commit, so `changelogs` cannot find the commits that introduced pending entries. Regenerating `v0.6.0` after #76 therefore attributed every release note to #76.

## What

- Fetch full Git history before running the pinned `changelogs` action.
- Leave package and release contents unchanged.
