### PR TITLE
fix(models): coerce hex-string quantities in from_dict

### DIFF
--- a/.changelog/from-dict-hex-quantities.md
+++ b/.changelog/from-dict-hex-quantities.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Fixed `TempoTransaction.from_dict` to accept JSON-RPC-style hex-string quantities (e.g. `{"chainId": "0xa5bd", "value": "0x64"}`). Previously such dicts — the standard Ethereum JSON encoding implied by the supported camelCase keys — raised `TypeError` during validation because quantities were left as strings. Decimal-string and integer inputs continue to work.

--- a/pytempo/models.py
+++ b/pytempo/models.py
@@ -286,12 +286,21 @@ class TempoTransaction:
                     return d[key]
             return default
 
-        chain_id = get_key("chainId", "chain_id", default=1)
-        max_priority_fee = get_key(
-            "maxPriorityFeePerGas", "max_priority_fee_per_gas", default=0
+        def as_int(value):
+            # Coerce JSON-RPC quantities (hex or decimal strings) to int.
+            if value is None or isinstance(value, int):
+                return value
+            if isinstance(value, str):
+                base = 16 if value.lower().startswith("0x") else 10
+                return int(value, base)
+            return value
+
+        chain_id = as_int(get_key("chainId", "chain_id", default=1))
+        max_priority_fee = as_int(
+            get_key("maxPriorityFeePerGas", "max_priority_fee_per_gas", default=0)
         )
-        max_fee = get_key("maxFeePerGas", "max_fee_per_gas", default=0)
-        gas_limit = get_key("gas", "gasLimit", "gas_limit", default=21_000)
+        max_fee = as_int(get_key("maxFeePerGas", "max_fee_per_gas", default=0))
+        gas_limit = as_int(get_key("gas", "gasLimit", "gas_limit", default=21_000))
 
         calls_data = get_key("calls", default=[])
         if not calls_data:
@@ -304,7 +313,7 @@ class TempoTransaction:
         calls = tuple(
             Call.create(
                 to=call.get("to", "") or b"",
-                value=call.get("value", 0),
+                value=as_int(call.get("value", 0)),
                 data=call.get("data", call.get("input", "0x")),
             )
             for call in calls_data
@@ -338,10 +347,10 @@ class TempoTransaction:
             gas_limit=gas_limit,
             calls=calls,
             access_list=access_list,
-            nonce_key=get_key("nonceKey", "nonce_key", default=0),
-            nonce=get_key("nonce", default=0),
-            valid_before=get_key("validBefore", "valid_before"),
-            valid_after=get_key("validAfter", "valid_after"),
+            nonce_key=as_int(get_key("nonceKey", "nonce_key", default=0)),
+            nonce=as_int(get_key("nonce", default=0)),
+            valid_before=as_int(get_key("validBefore", "valid_before")),
+            valid_after=as_int(get_key("validAfter", "valid_after")),
             fee_token=fee_token,
             awaiting_fee_payer=bool(
                 get_key("_will_have_fee_payer", "awaiting_fee_payer", default=False)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -84,3 +84,37 @@ def test_batch_calls():
     assert len(tx.calls) == 2
     assert tx.calls[0].value == 0
     assert tx.calls[1].value == 100
+
+
+def test_from_dict_coerces_hex_string_quantities():
+    """JSON-RPC dicts hex-encode quantities; from_dict must accept them."""
+    tx = TempoTransaction.from_dict(
+        {
+            "chainId": "0xa5bd",
+            "maxFeePerGas": "0x77359400",
+            "maxPriorityFeePerGas": "0x1",
+            "gas": "0x186a0",
+            "nonce": "0x5",
+            "to": "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55",
+            "value": "0x64",
+            "data": "0x",
+        }
+    )
+    tx.validate()
+    assert tx.chain_id == 0xA5BD
+    assert tx.max_fee_per_gas == 0x77359400
+    assert tx.max_priority_fee_per_gas == 1
+    assert tx.gas_limit == 0x186A0
+    assert tx.nonce == 5
+    assert tx.calls[0].value == 100
+
+
+def test_from_dict_accepts_int_quantities():
+    """Snake_case/int dicts still parse (no regression)."""
+    tx = TempoTransaction.from_dict(
+        {"chain_id": 42429, "gas": 100_000, "value": 7, "to": "0x" + "a" * 40}
+    )
+    tx.validate()
+    assert tx.chain_id == 42429
+    assert tx.gas_limit == 100_000
+    assert tx.calls[0].value == 7


### PR DESCRIPTION
`TempoTransaction.from_dict` accepts camelCase keys (`chainId`, `maxFeePerGas`, `gas`, `value`, ...), which is the Ethereum JSON-RPC convention — where quantities are **hex strings** (e.g. `"0x64"`). But it passed those values through unconverted, so parsing a standard JSON-RPC transaction dict raised `TypeError: '<' not supported between instances of 'str' and 'int'` during `validate()`.

```python
TempoTransaction.from_dict({"chainId": "0xa5bd", "gas": "0x186a0", "value": "0x64", ...})  # TypeError
```

This coerces quantity fields (`chain_id`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `gas_limit`, `nonce`, `nonce_key`, `valid_before`, `valid_after`, and per-call `value`) via a small `as_int` helper that accepts hex strings, decimal strings, and ints. Integer and snake_case inputs are unaffected. Adds tests for both hex-string and int inputs.