### PR TITLE
fix: skip changelog generation for fork PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   changelog:
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Motivation

Fork pull requests fail during changelog checkout because their head branches are not present in the base repository.

## Summary

- Skip changelog generation for fork pull requests.
- Skip generation for Dependabot pull requests without secret access.

## Key design considerations

- Preserve automatic changelog generation for same-repository contributor branches.