### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 
@@ -92,7 +92,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 
@@ -177,7 +177,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 
@@ -203,7 +203,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@487be2d19b0ba9ae1903143016444ab752c3e939
         with:
           version: "0.7.12"
 


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/487be2d19b0ba9ae1903143016444ab752c3e939/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `astral-sh/setup-uv` | [`tempoxyz/gh-actions/vendor/astral-sh/setup-uv`](https://github.com/tempoxyz/gh-actions/tree/487be2d19b0ba9ae1903143016444ab752c3e939/vendor/astral-sh/setup-uv) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 4 -> 4).
