### PR TITLE
test(keychain): restore selector authorization

### DIFF
--- a/.changelog/kind-sharks-play.md
+++ b/.changelog/kind-sharks-play.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Restored live integration coverage for direct AccountKeychain authorization selectors, replacing the TIP-1099 transaction-embedded authorization approach with direct `authorizeKey` precompile selector calls.

--- a/.changelog/restore-keychain-selector-integration.md
+++ b/.changelog/restore-keychain-selector-integration.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Restored live integration coverage for direct AccountKeychain authorization selectors.

--- a/.changelog/tip1099-integration-authorization.md
+++ b/.changelog/tip1099-integration-authorization.md
@@ -1,5 +1,0 @@
----
-pytempo: patch
----
-
-Updated live keychain integration coverage to use transaction-embedded authorization on TIP-1099 networks.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -812,10 +812,14 @@ class TestSetUserFeeToken:
         assert receipt["status"] == 1
 
 
-class TestKeychainLifecycle:
-    """Test inline key authorization followed by keychain queries and revocation."""
+class TestKeychainSelectors:
+    """Test keychain precompile selectors (authorizeKey, getKey, revokeKey).
 
-    def test_authorize_get_revoke_round_trip(self, w3, chain_id, funded_account):
+    Parity with tempo-go TestIntegration_KeychainSelectors: exercises the
+    authorizeKey → getKey → revokeKey round-trip via the precompile.
+    """
+
+    def test_authorize_get_revoke_round_trip(self, w3, chain_id, funded_account, is_t2):
         """Authorize an access key, verify via getKey, revoke, verify revoked."""
         max_fee, priority_fee = get_gas_params(w3)
 
@@ -823,47 +827,23 @@ class TestKeychainLifecycle:
         # 10 years from now
         expiry = int(time.time()) + 10 * 365 * 24 * 3600
 
-        # Step 1: Authorize through the transaction key_authorization field. TIP-1099
-        # removes the direct authorizeKey precompile selectors at T11.
-        auth = KeyAuthorization(
+        # Step 1: Authorize key via EIP-1559 tx (same as tempo-go)
+        nonce = w3.eth.get_transaction_count(funded_account.address)
+        auth_call = AccountKeychain.authorize_key(
             key_id=access_key.address,
-            chain_id=chain_id,
-            key_type=SignatureType.SECP256K1,
-            expiry=expiry,
-        )
-        signed_auth = auth.sign(funded_account.key.hex())
-        nonce_key = 3000 + (int(time.time()) % 10000)
-        tx = TempoTransaction.create(
-            chain_id=chain_id,
-            nonce=0,
-            nonce_key=nonce_key,
-            gas_limit=0,
-            max_fee_per_gas=max_fee,
-            max_priority_fee_per_gas=priority_fee,
-            calls=(Call.create(to=COUNTER_CONTRACT, data=COUNTER_INCREMENT),),
-            key_authorization=signed_auth,
-        )
-        gas_estimate = w3.eth.estimate_gas(
-            tx.to_estimate_gas_request(
-                funded_account.address,
-                key_id=access_key.address,
-                key_authorization=signed_auth,
-            )
+            signature_type=SignatureType.SECP256K1,
+            restrictions=KeyRestrictions(expiry=expiry),
+            legacy=is_t2,
         )
         tx = TempoTransaction.create(
             chain_id=chain_id,
-            nonce=0,
-            nonce_key=nonce_key,
-            gas_limit=gas_estimate,
+            nonce=nonce,
+            gas_limit=600_000,
             max_fee_per_gas=max_fee,
             max_priority_fee_per_gas=priority_fee,
-            calls=(Call.create(to=COUNTER_CONTRACT, data=COUNTER_INCREMENT),),
-            key_authorization=signed_auth,
+            calls=(auth_call,),
         )
-        signed = tx.sign_access_key(
-            access_key_private_key=access_key.key.hex(),
-            root_account=funded_account.address,
-        )
+        signed = tx.sign(funded_account.key.hex())
         receipt = send_tx(w3, signed)
         assert receipt["status"] == 1
 


### PR DESCRIPTION
Restores the direct `authorizeKey` integration flow removed in #85 now that TIP-1099 is not proceeding. The changelog now reflects selector-based key authorization coverage.

Prompted by: @klkvr
