### PR TITLE
fix(decode): reject address words with non-zero upper bytes

### DIFF
--- a/pytempo/contracts/_decode.py
+++ b/pytempo/contracts/_decode.py
@@ -35,8 +35,18 @@ def decode_bool(result: bytes, name: str) -> bool:
 
 
 def decode_address(result: bytes, name: str) -> str:
-    """Decode an address encoded in a single ABI word."""
-    return to_checksum_address(decode_word(result, name)[-20:])
+    """Decode an address encoded in a single ABI word.
+
+    A canonical ABI address word left-pads the 20-byte address with 12 zero
+    bytes; reject non-zero upper bytes rather than silently discarding them, so
+    a malformed response is not accepted as a valid address.
+    """
+    word = decode_word(result, name)
+    if word[:12] != b"\x00" * 12:
+        raise ValueError(
+            f"{name} result has non-zero upper bytes for a 20-byte address"
+        )
+    return to_checksum_address(word[-20:])
 
 
 def decode_hash32(result: bytes, name: str) -> bytes:

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,0 +1,49 @@
+"""Tests for the internal fixed-width ABI decode helpers."""
+
+import pytest
+from eth_utils import to_checksum_address
+
+from pytempo.contracts._decode import (
+    decode_address,
+    decode_bool,
+    decode_u64,
+    decode_word,
+)
+
+# 20 non-zero address bytes.
+ADDR = bytes(range(1, 21))
+
+
+class TestDecodeAddress:
+    def test_decodes_canonical_word(self):
+        word = b"\x00" * 12 + ADDR
+        assert decode_address(word, "addr") == to_checksum_address(ADDR)
+
+    def test_rejects_non_zero_upper_bytes(self):
+        # A canonical ABI address word left-pads the 20-byte address with 12
+        # zero bytes; non-zero upper bytes indicate a malformed response and
+        # must not be silently discarded (matching decode_bool / decode_u64,
+        # which also reject non-canonical words).
+        word = b"\xff" * 12 + ADDR
+        with pytest.raises(ValueError, match="upper bytes"):
+            decode_address(word, "addr")
+
+    def test_rejects_wrong_length(self):
+        with pytest.raises(ValueError, match="32 bytes"):
+            decode_address(b"\x00" * 31, "addr")
+
+
+class TestDecodeStrictnessSiblings:
+    """The decode helpers deliberately reject non-canonical words."""
+
+    def test_bool_rejects_non_canonical(self):
+        with pytest.raises(ValueError, match="ABI bool"):
+            decode_bool((2).to_bytes(32, "big"), "flag")
+
+    def test_u64_rejects_overflow(self):
+        with pytest.raises(ValueError, match="exceeds uint64"):
+            decode_u64((2**64).to_bytes(32, "big"), "amount")
+
+    def test_word_rejects_wrong_length(self):
+        with pytest.raises(ValueError, match="32 bytes"):
+            decode_word(b"\x00" * 33, "word")


### PR DESCRIPTION
## Summary

`decode_address` returned the last 20 bytes of the ABI word and **silently discarded the upper 12**, so a malformed word such as `0xffff…ffff<20-byte-addr>` was accepted as a valid address:

```python
return to_checksum_address(decode_word(result, name)[-20:])
```

This is inconsistent with the rest of `_decode.py`, which deliberately rejects non-canonical words — `decode_bool` rejects values other than `0`/`1`, and `decode_u64` rejects overflow. A canonical ABI address word left-pads the 20-byte address with 12 zero bytes, so non-zero upper bytes signal a malformed response and shouldn't be quietly dropped.

## Fix

Reject a non-zero upper 12 bytes with the same `ValueError` style the sibling decoders use:

```python
word = decode_word(result, name)
if word[:12] != b"\x00" * 12:
    raise ValueError(f"{name} result has non-zero upper bytes for a 20-byte address")
return to_checksum_address(word[-20:])
```

Canonical words decode exactly as before.

## Tests

Adds `tests/test_decode.py` (these internal decoders had no dedicated test file): the address strictness fix — canonical word accepted, non-zero upper bytes rejected, wrong length rejected — plus sibling guards for `decode_bool` / `decode_u64` / `decode_word`.

`pytest` passes (272 passed, 36 skipped; +6). `ruff check` and `ruff format --check` are clean.
