### PR TITLE
fix(keychain): reject dirty recipient word in is_call_allowed

### DIFF
--- a/.changelog/fix-is-call-allowed-recipient-word.md
+++ b/.changelog/fix-is-call-allowed-recipient-word.md
@@ -1,0 +1,5 @@
+---
+pytempo: patch
+---
+
+Fixed `KeyRestrictions.is_call_allowed` to reject a recipient-constrained call whose first ABI word after the selector has non-zero upper bytes. It now requires a clean ABI-encoded address (upper 12 bytes zero) before comparing the recipient, matching `tempo_alloy`'s `call_scopes_allow` and the on-chain precompile. Previously the upper 12 bytes were ignored, so a malformed word could be reported as allowed even though the chain rejects it.

--- a/pytempo/keychain.py
+++ b/pytempo/keychain.py
@@ -403,8 +403,9 @@ class KeyRestrictions:
         3. Scope has no selector rules → any call to that target is allowed.
         4. Selector not in rules → denied.
         5. Rule has no recipients → any recipient is allowed.
-        6. Otherwise the first ABI word after the selector must match an
-           allowed recipient.
+        6. Otherwise the first ABI word after the selector must be a clean
+           ABI-encoded address (upper 12 bytes zero) matching an allowed
+           recipient.
         """
         if self.allowed_calls is None:
             return True
@@ -440,6 +441,14 @@ class KeyRestrictions:
             return False
 
         word = input_data[4:36]
+        # Recipient-constrained selectors only permit a clean ABI-encoded
+        # address: the upper 12 bytes of the word must be zero.  This mirrors
+        # tempo_alloy's ``call_scopes_allow`` and the on-chain precompile, both
+        # of which reject a word with dirty upper bytes before comparing the
+        # recipient.  Without this guard pytempo would report a call as allowed
+        # that the chain rejects.
+        if any(word[:12]):
+            return False
         recipient = as_address(word[12:])
         return recipient in rule.recipients
 

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -1451,6 +1451,23 @@ class TestKeyRestrictionsIsCallAllowed:
         input_bad.extend(b"\x00" * 32)
         assert not r.is_call_allowed(token, bytes(input_bad))
 
+    def test_recipient_word_dirty_upper_bytes_denied(self):
+        # The recipient word must be a clean ABI-encoded address: the upper 12
+        # bytes must be zero.  tempo_alloy's call_scopes_allow and the on-chain
+        # precompile both reject a word with non-zero upper bytes even when the
+        # low 20 bytes match an allowed recipient, so pytempo must too.
+        token = ALPHA_USD
+        allowed = "0x" + "44" * 20
+        r = KeyRestrictions(
+            allowed_calls=[CallScope.transfer(target=token, recipients=[allowed])],
+        )
+        input_dirty = bytearray()
+        input_dirty.extend(_TRANSFER_SELECTOR)
+        input_dirty.extend(b"\x00" * 11 + b"\x01")  # non-zero upper byte
+        input_dirty.extend(bytes.fromhex("44" * 20))  # allowed recipient (low 20 bytes)
+        input_dirty.extend(b"\x00" * 32)
+        assert not r.is_call_allowed(token, bytes(input_dirty))
+
     def test_recipient_word_too_short(self):
         token = ALPHA_USD
         allowed = "0x" + "44" * 20


### PR DESCRIPTION
## Summary

`KeyRestrictions.is_call_allowed` documents that its resolution order "matches the Rust implementation", but for a recipient-constrained selector it extracts the recipient from the low 20 bytes of the first ABI word and ignores the upper 12 bytes:

```python
word = input_data[4:36]
recipient = as_address(word[12:])
return recipient in rule.recipients
```

The Rust it mirrors does not. Both the client-side reference `tempo_alloy::call_scopes_allow` and the on-chain precompile (`AccountKeychain::validate_call_scope_for_transaction`) require the upper 12 bytes of that word to be zero before comparing the recipient, and deny the call otherwise:

```rust
let word: [u8; 32] = input.get(4..36)?.try_into().ok()?;
if word[..12].iter().any(|byte| *byte != 0) {
    return Some(false);
}
Some(rule.recipients.contains(&Address::from_slice(&word[12..])))
```

So for calldata whose first word has non-zero upper bytes but whose low 20 bytes happen to match an allowed recipient, `is_call_allowed` returns `True` while the chain rejects the call. A caller that trusts the helper to pre-check an access key would build and sign a transaction that then reverts on-chain.

## Fix

Add the same zero-upper-bytes guard before extracting the recipient, so the client agrees with `call_scopes_allow` and the precompile.

## Test

Adds `test_recipient_word_dirty_upper_bytes_denied` for the dirty-upper-bytes case; the existing tests only exercised well-formed, zero-padded recipient words.
